### PR TITLE
Fixes for table equation rendering

### DIFF
--- a/Slides/Code.js
+++ b/Slides/Code.js
@@ -148,13 +148,11 @@ function findTextOffsetInSlide(str, search, offset = 0){
   }
   let slides = IntegratedApp.getBody()
   let childCount = slides.length;
-  for (var x = 0; x < 5; x++){ //please remove this, this is a terrible fix
-    for (var slideNum = 0; slideNum < childCount; slideNum++){
-      for (var elementNum = 0; elementNum < slides[slideNum].getPageElements().length; elementNum++){
-        debugLog("Slide Num: " + slideNum + " Num of shapes: " + slides[slideNum].getPageElements().length);
-        findPos(slideNum, elementNum, delim, quality, size, defaultSize, isInline);   //or: "\\\$\\\$", "\\\$\\\$"
-        c = c + 1;
-      }
+  for (var slideNum = 0; slideNum < childCount; slideNum++){
+    for (var elementNum = 0; elementNum < slides[slideNum].getPageElements().length; elementNum++){
+      debugLog("Slide Num: " + slideNum + " Num of shapes: " + slides[slideNum].getPageElements().length);
+      findPos(slideNum, elementNum, delim, quality, size, defaultSize, isInline);   //or: "\\\$\\\$", "\\\$\\\$"
+      c++;
     }
   }
   


### PR DESCRIPTION
### Changes:
* All the equations in tables (even those bigger than 10x10) will be rendered
* Font colors for equations in tables are respected

Because there's no simple way to get the position of a table _cell_, all of the table equations are positioned over the first cell

### Questions:

What is this for loop fixing? Why do you need to do 5 passes?

https://github.com/Divide-By-0/autolatex/blob/1e13acca16647489e595f865820e7c7dffa6edb7/Slides/Code.js#L151-L159

I'm getting the "Sorry, the equation is too long or another problem occurred." error a lot, even though all of the equations are being rendered. Do you know why this is?