### PR TITLE
Add MathJax renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *node_modules*
 *.clasp.json
 *.DS_Store
-Slides/Sidebar.js
-Docs/Sidebar.js
+Sidebar.js
+Sidebar.js
+Common/MathJax.js

--- a/Common/.claspignore
+++ b/Common/.claspignore
@@ -1,0 +1,2 @@
+mathjax/mathjax.ts
+mathjax/build.mjs

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -7,13 +7,13 @@ const DEBUG = true; //doing ctrl + m to get key to see errors is still needed; D
  * @public
  */
 interface Renderer {
-  0: number;
-  1: string;
-  2: string;
-  3: string;
-  4: string;
-  5: string;
-  6: string;
+  image: string;
+  editor: string;
+  inlineStart: string;
+  inlineEnd: string;
+  name: string;
+  // the part that gets rendered in browser in the fake call but not in the link(No Machine name substring)
+  editorEnd: string;
 };
 
 /**
@@ -56,7 +56,116 @@ let previousTime = 0;
 let previousLine = 0;
 let equationRenderingTime = 0;
 let codecogsSlow = 0;
-let texrendrDown = 0;
+
+const codeCogsRenderers: Renderer[] = [
+  {
+    image: "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
+    editor: "https://www.codecogs.com/eqnedit.php?latex=",
+    inlineStart: "%5Cinline%20",
+    inlineEnd: "",
+    name: "Codecogs",
+    editorEnd: "%5Cdpi%7B900%7D",
+  },
+  {
+    image: "https://latex-staging.easygenerator.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
+    editor: "https://latex-staging.easygenerator.com/eqneditor/editor.php?latex=",
+    inlineStart: "%5Cinline%20",
+    inlineEnd: "",
+    name: "Codecogs",
+    editorEnd: "%5Cdpi%7B900%7D",
+  },
+  {
+    image: "https://latex.codecogs.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
+    editor: "https://www.codecogs.com/eqnedit.php?latex=",
+    inlineStart: "%5Cinline%20",
+    inlineEnd: "",
+    name: "Codecogs",
+    editorEnd: "%5Cdpi%7B900%7D",
+  }
+];
+const sciWeaverRenderer: Renderer = {
+  image: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=EQUATION",
+  editor: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=",
+  inlineStart: "%5Ctextstyle%20%7B",
+  inlineEnd: "%7D",
+  name: "Sciweavers",
+  editorEnd: ""
+};
+const texRendrRenderer: Renderer = {
+  image: "http://texrendr.com/cgi-bin/mimetex?%5CHuge%20EQUATION",
+  editor: "http://www.texrendr.com/?eqn=",
+  inlineStart: "%5Ctextstyle%20",
+  inlineEnd: "",
+  name: "Texrendr",
+  editorEnd: ""
+};
+// renderers not affected by changing priorities
+const otherRenderers: Renderer[] = [
+  {
+    image: "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
+    editor: "https://www.codecogs.com/eqnedit.php?latex=",
+    inlineStart: "%5Cinline%20",
+    inlineEnd: "",
+    name: "Codecogs",
+    editorEnd: "%5Cdpi%7B900%7D",
+  },
+  {
+    image: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=EQUATION",
+    editor: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=",
+    inlineStart: "%5Ctextstyle%20%7B",
+    inlineEnd: "%7D",
+    name: "Sciweavers",
+    editorEnd: "",
+  },
+  {
+    image: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=EQUATION",
+    editor: "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=",
+    inlineStart: "%5Ctextstyle%20%7B",
+    inlineEnd: "%7D",
+    name: "Sciweavers",
+    editorEnd: "",
+  },
+  {
+    image: "http://rogercortesi.com/eqn/tempimagedir/_FILENAME.png",
+    editor: "http://rogercortesi.com/eqn/index.php?filename=_FILENAME.png&outtype=png&bgcolor=white&txcolor=black&res=1800&transparent=1&antialias=0&latextext=",
+    inlineStart: "%5Ctextstyle%20%7B",
+    inlineEnd: "%7D",
+    name: "Roger's renderer",
+    editorEnd: "",
+  },
+  {
+    image: "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=EQUATION",
+    editor: "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=",
+    inlineStart: "%5Ctextstyle%20%7B",
+    inlineEnd: "%7D",
+    name: "Sciweavers_old",
+    editorEnd: "",
+  },
+  {
+    image: "http://latex.numberempire.com/render?EQUATION&sig=41279378deef11cbe78026063306e50d",
+    editor: "http://latex.numberempire.com/render?",
+    inlineStart: "%5Ctextstyle%20%7B",
+    inlineEnd: "%7D",
+    name: "Number empire",
+    editorEnd: "",
+  },
+  {
+    image: "https://texrendr.com/cgi-bin/mathtex.cgi?%5Cdpi%7B1800%7DEQUATION",
+    editor: "https://www.texrendr.com/?eqn=",
+    inlineStart: "%5Ctextstyle%20",
+    inlineEnd: "",
+    name: "Texrendr",
+    editorEnd: ""
+  },
+  {
+    image: "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
+    editor: "https://www.codecogs.com/eqnedit.php?latex=", inlineStart: "%5Cinline%20",
+    inlineEnd: "",
+    name: "Codecogs",
+    editorEnd: "%5Cdpi%7B900%7D"
+  },
+];
+
 /**
  * @public
  */
@@ -66,18 +175,25 @@ const capableRenderers = 8;
  */
 const capableDerenderers = 12;
 //render bug variables
+
 /**
  * @public
  */
-const invalidEquationHashCodecogsFirst50 = "GIF89a%7F%00%18%00%uFFFD%00%00%uFFFD%u0315%uFFFD3%"; // invalid codecogs equation
-const invalidEquationHashCodecogsFirst50_3 = "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%01%"; // this is one space in codecogs. not pushed yet.
-const invalidEquationHashCodecogsFirst50_4 = "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0";
-const invalidEquationHashCodecogsFirst50_5 = "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00z%00";
-const invalidEquationHashTexrendrFirst50 = "GIF89a%uFFFD%008%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%";
-const invalidEquationHashTexrendrFirst50_2 = "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0";
-const invalidEquationHashTexrendrFirst50_3 = "GIF89ai%0A%uFFFD%01%uFFFD%00%00%uFFFD%uFFFD%uFFFD%"; // this is the No Expression Supplied error. Ignored for now.
-const invalidEquationHashTexrendrFirst50_4 = "%7FELF%01%01%01%00%00%00%00%00%00%00%00%00%02%00%0";
-const invalidEquationHashSciweaversFirst50 = "%0D%0A%09%3C%21DOCTYPE%20html%20PUBLIC%20%22-//W3C";
+const invalidEquationHashesCodecogs = new Set([
+  "GIF89a%7F%00%18%00%uFFFD%00%00%uFFFD%u0315%uFFFD3%", // invalid codecogs equation
+  "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%01%", // this is one space in codecogs. not pushed yet.
+  "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0",
+  "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00z%00",
+]);
+const invalidEquationHashesTexrendr = new Set([
+  "GIF89a%uFFFD%008%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%",
+  "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0",
+  "GIF89ai%0A%uFFFD%01%uFFFD%00%00%uFFFD%uFFFD%uFFFD%", // this is the No Expression Supplied error. Ignored for now.
+  "%7FELF%01%01%01%00%00%00%00%00%00%00%00%00%02%00%0"
+]);
+const invalidEquationHashSciweavers = new Set([
+  "%0D%0A%09%3C%21DOCTYPE%20html%20PUBLIC%20%22-//W3C"
+]);
 
 /**
  * @public
@@ -194,18 +310,17 @@ function deEncode(equation: string) {
  * Using the encoded equation, add the commands for high quality, inline or not (based on size neg or pos), and returns it.
  *
  * @param  equationStringEncoded  The encoded equation.
- * @param quality                The dpi quality to be rendered in (default 900).
  * @param inlineStyle            The text to be inserted for inline text, dependent on CodeCogs or TeXRendr.
  * @param size                   The size of the text, whose neg/pos indicated whether the equation is inline or not.
  */
 
-function getStyle(equationStringEncoded: string, quality: number, renderer: Renderer, isInline: boolean, type: number, red: number, green: number, blue: number) {
+function getStyle(equationStringEncoded: string, renderer: Renderer, isInline: boolean, type: number, red: number, green: number, blue: number) {
   //ERROR?
   const equation: string[] = [];
   equationStringEncoded = equationStringEncoded;
   reportDeltaTime(307);
   if (isInline) {
-    equationStringEncoded = renderer[3] + "%7B%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded + renderer[4] + "%7D";
+    equationStringEncoded = renderer.inlineStart + "%7B%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded + renderer.inlineEnd + "%7D";
   } else {
     equationStringEncoded = "%7B%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded + "%7D";
   }
@@ -258,125 +373,124 @@ function renderEquation(equationOriginal: string, quality: number, delim: Delimi
   var equation = "";
   let renderer: Renderer | null = null;
   let resp: GoogleAppsScript.URL_Fetch.HTTPResponse | null = null;
-  let failure = 1;
-  let rendererType = "";
   let deltaTime: number;
-  let worked = 1;
 
-  let failedCodecogs = 0;
-  let failedTexrendr = 0;
-  let failedResp: GoogleAppsScript.URL_Fetch.HTTPResponse | null = null;
   // if only failed codecogs, probably weird evening bug from 10/15/19
   // if failed codecogs and texrendr, probably shitty equation and the codecogs error is more descriptive so show it
+  let codecogsFailedResp: GoogleAppsScript.URL_Fetch.HTTPResponse | null = null;
+  let texrenderFailCount = 0;
+  let codecogsFailCount = 0;
 
   // note the last few renderers might be legacy, so ignored
-  for (; worked <= capableRenderers; ++worked) {
-    //[3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
+  for (let worked = 1; worked <= capableRenderers; ++worked) {
     try {
       renderer = getRenderer(worked);
-      rendererType = renderer[5];
-      equation = getStyle(equationOriginal, quality, renderer, isInline, worked, red, green, blue);
-      // console.log(rendererType, "Texrendr", rendererType == "Texrendr")
-      if (rendererType == "Texrendr") {
-        // console.log("Used texrendr", equation, equation.replace("%5C%5C", "%0D"))
-        equation = equation.split("%A0").join("%0D"); //.replace("%5C%5C", "%0D") .replace("%C2%AD", "%0D")
-      } else if (rendererType == "Codecogs") {
-        // console.log("Used Codecogs", equation, equation.split("%5C%5C%5C%5C").join("%5C%5C"))
-        equation = equation.split("%5C%5C%5C%5C").join("%5C%5C"); //.replace("%A0", "%0D") .replace("%C2%AD", "%0D")
-      } else if (rendererType == "Sciweavers") {
-        // console.log("Used Sciweavers", equation, equation.split("%5C%5C%5C%5C").join("%5C%5C"))
-        equation = equation.split("%5C%5C%5C%5C").join("%5C%5C"); //.replace("%A0", "%0D") .replace("%C2%AD", "%0D")
+      equation = getStyle(equationOriginal, renderer, isInline, worked, red, green, blue);
+
+      // renderer-specific replacements
+      switch (renderer.name) {
+        case "Texrendr":
+          equation = equation.replaceAll("%A0", "%0D");
+          break;
+        case "Codecogs":
+        case "Sciweavers":
+          equation = equation.replaceAll("%5C%5C%5C%5C", "%5C%5C");
+          break;
       }
 
       debugLog("Raw equation", equation);
-      renderer[1] = renderer[1].split("FILENAME").join(getFilenameEncode(equation, 0));
-      renderer[1] = renderer[1].split("EQUATION").join(equation);
-      renderer[2] = renderer[2].split("FILENAME").join(getFilenameEncode(equation, 0)); // since mutating original object, important each is a new one
-      debugLog("Link with equation", renderer[1]);
-      debugLog("Title Alt Text " + renderer[2] + equationOriginal + "#" + delim[6]);
-      debugLog("Cached equation: " + renderer[2] + renderer[6] + equation);
-      reportDeltaTime(453);
-      console.log("Fetching ", renderer[1], " and ", renderer[2] + renderer[6] + equation);
+      const equationFilename = getFilenameEncode(equation, 0);
+      const imageUrl = renderer.image
+        .replace("FILENAME", equationFilename)
+        .replace("EQUATION", equation);
 
-      const _createFileInCache = UrlFetchApp.fetch(renderer[2] + renderer[6] + equation);
+      const baseEditorUrl = renderer.editor.replace("FILENAME", equationFilename);
+      const editorCacheUrl = baseEditorUrl + renderer[6] + equation;
+      // equation original with the delim
+      const editorOriginalEqUrl = baseEditorUrl + equationOriginal + "#" + delim[6];
+      
+      
+      debugLog("Link with equation:", imageUrl);
+      debugLog("Title Alt Text:", editorOriginalEqUrl);
+      debugLog("Cached equation:", editorCacheUrl);
+      reportDeltaTime(453);
+      console.log(`Fetching ${imageUrl} and ${editorCacheUrl}`);
+
       // simulates putting text into text renderer => creates link for cached image which is accessed later
       // needed for codecogs to generate equation properly, need to figure out which other renderers need this. to test, use align* equations.
+      UrlFetchApp.fetch(editorCacheUrl);
 
-      reportDeltaTime(458, " fetching w eqn len " + equation.length + " with renderer " + rendererType);
-      if (rendererType == "Codecogs" || rendererType == "Sciweavers") {
+      reportDeltaTime(458, " fetching w eqn len " + equation.length + " with renderer " + renderer.name);
+      if (renderer.name === "Codecogs" || renderer.name === "Sciweavers") {
         Utilities.sleep(50); // sleep 50ms to let codecogs put the equation in its cache
       }
-      resp = UrlFetchApp.fetch(renderer[1]);
-      debugLog(resp, resp.getBlob(), escape(resp.getBlob().getDataAsString()).substring(0, 50));
-      deltaTime = reportDeltaTime(470, " equation link length " + renderer[1].length + " and renderer  " + rendererType);
-      console.log("Hash ", escape(resp.getBlob().getDataAsString()).substring(0, 50));
-      if (!escape(resp.getBlob().getDataAsString())) {
+      resp = UrlFetchApp.fetch(imageUrl);
+
+      deltaTime = reportDeltaTime(470, ` equation link length ${imageUrl.length} and renderer ${renderer.name}`);
+;
+
+      const equationHash = escape(resp.getBlob().getDataAsString()).substring(0, 50);
+      debugLog(resp, resp.getBlob(), equationHash);
+      
+      if (!equationHash) {
         // if there is no hash, codecogs failed
         throw new Error("Saw NO Codecogs equation hash! Renderer likely down!");
-      } else if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashSciweaversFirst50) {
-        // if there is no hash, codecogs failed
+      } else if (invalidEquationHashSciweavers.has(equationHash) && renderer.name === "Sciweavers") {
+        // sciweavers error
         throw new Error("Saw weburl Sciweavers equation hash! Equation likely contains amsmath!");
-      } else if (
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_3 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_4 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_5
-      ) {
-        console.log("Invalid Codecogs Equation! Times: " + failedCodecogs + failedTexrendr);
-        failedCodecogs += 1;
-        failedResp = resp;
-        if (failedCodecogs && failedTexrendr) {
-          // if in order so failed codecogs first
+      } else if (invalidEquationHashesCodecogs.has(equationHash) && renderer.name === "Codecogs") {
+        console.log(`Invalid Codecogs Equation! Fail count: ${texrenderFailCount + codecogsFailCount}`);
+        codecogsFailedResp = resp;
+        codecogsFailCount++;
+        
+        if (texrenderFailCount) {
+          // texrender also failed, so just display the error from codecogs
           console.log("Displaying codecogs error!");
-          resp = failedResp; // let it continue to completion with the failed codecogs equation
         } else {
+          // throw an error, and try with other renderers (like texrender too)
           throw new Error("Saw invalid Codecogs equation hash!");
         }
-      } // have no idea if I can put an else here or not lol
-      if (
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_2 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_3 ||
-        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_4
-      ) {
-        console.log("Invalid Texrendr Equation! Times: " + failedCodecogs + failedTexrendr);
-        failedTexrendr += 1;
-        if (failedCodecogs && failedTexrendr) {
+      } else if (invalidEquationHashesTexrendr.has(equationHash) && renderer.name === "Texrendr") {
+        console.log(`Invalid Texrendr Equation! Fail count: ${texrenderFailCount + codecogsFailCount}`);
+        texrenderFailCount++;
+        
+        if (codecogsFailedResp) {
           // if in order so failed codecogs first
-          console.log("Displaying Texrendr error!");
-          if (failedResp)
-            resp = failedResp; // let it continue to completion with the failed codecogs equation
+          console.log("Displaying Codecogs error instead!");
+          resp = codecogsFailedResp; // let it continue to completion with the failed codecogs equation
+          renderer = codeCogsRenderers[0];
         } else {
           // should only execute if texrendr is 1
           throw new Error("Saw invalid Texrendr equation hash!");
         }
       }
-      if (deltaTime > 10000 && rendererType == "Codecogs" && renderer[0] <= 3) {
+
+      // Deprioritize Codecogs if it was slow
+      // if worked > 3, then codecogsSlow was already true
+      if (deltaTime > 10000 && renderer.name == "Codecogs" && worked <= 3) {
         console.log("Codecogs accurate but is slow! Switching renderer priority.");
         codecogsSlow = 1;
       }
-      failure = 0;
-      console.log("Worked with renderer ", worked, " and type ", rendererType);
-      break;
+      console.log(`Worked with ${renderer.name} (${worked})`);
+
+      // return the 
+      return {
+        imageBlob: resp.getBlob(),
+        renderer,
+        editorOriginalEqUrl,
+        equation,
+        isCodecogsError: resp === codecogsFailedResp
+      };
     } catch (err) {
-      console.log(rendererType + " Error! - " + err);
-      deltaTime = reportDeltaTime(533, " failed equation link length " + renderer![1].length + " and renderer  " + rendererType);
-      if (rendererType == "Texrendr") {
-        // equation.indexOf("align")==-1 &&  removed since align now supported
-        console.log("Texrendr likely down, deprioritized!");
-        texrendrDown = 1;
-      }
+      // an error occurred; continue to the next renderer
+      
+      console.log(`${renderer.name} Error! - ${err}`);
+      
+      deltaTime = reportDeltaTime(533, ` failed equation link length ${renderer![1].length} and renderer ${renderer.name}`);
     }
-    if (failure == 0) break;
   }
 
-  return {
-    resp,
-    renderer,
-    rendererType,
-    worked,
-    equation
-  }
+  return null;
 }
 
 /**
@@ -410,129 +524,17 @@ function sizeImage(app: IntegratedApp, paragraph: GoogleAppsScript.Document.Para
  * @public
  */
 function getRenderer(worked: number): Renderer {
-  //  order of execution ID, image URL, editing URL, in-line commandAt the beginning, in-line command at and, Human name, the part that gets rendered in browser in the fake call but not in the link(No Machine name substring)
-  let codeCogsPriority = 1;
-  let sciWeaverPriority = 5;
-  let texRenderPriority = 4;
-  if (codecogsSlow) {
-    sciWeaverPriority = 1;
-    codeCogsPriority = 3;
-    texRenderPriority = 2;
-  } //t , c, s
-  if (worked == codeCogsPriority) {
-    return [
-      codeCogsPriority,
-      "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
-      "https://www.codecogs.com/eqnedit.php?latex=",
-      "%5Cinline%20",
-      "",
-      "Codecogs",
-      "%5Cdpi%7B900%7D",
-    ];
-  } else if (worked == codeCogsPriority + 1) {
-    return [
-      codeCogsPriority + 1,
-      "https://latex-staging.easygenerator.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
-      "https://latex-staging.easygenerator.com/eqneditor/editor.php?latex=",
-      "%5Cinline%20",
-      "",
-      "Codecogs",
-      "%5Cdpi%7B900%7D",
-    ];
-  } else if (worked == codeCogsPriority + 2) {
-    return [
-      codeCogsPriority + 2,
-      "https://latex.codecogs.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
-      "https://www.codecogs.com/eqnedit.php?latex=",
-      "%5Cinline%20",
-      "",
-      "Codecogs",
-      "%5Cdpi%7B900%7D",
-    ];
-  } else if (worked == texRenderPriority) {
-    return [texRenderPriority, "http://texrendr.com/cgi-bin/mimetex?%5CHuge%20EQUATION", "http://www.texrendr.com/?eqn=", "%5Ctextstyle%20", "", "Texrendr", ""];
-  } //http://rogercortesi.com/eqn/index.php?filename=tempimagedir%2Feqn3609.png&outtype=png&bgcolor=white&txcolor=black&res=900&transparent=1&antialias=1&latextext=  //removed %5Cdpi%7B900%7D
-  else if (worked == sciWeaverPriority) {
-    return [
-      sciWeaverPriority,
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=EQUATION",
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Sciweavers",
-      "",
-    ];
-  } //not latex font
-  else if (worked == 6) {
-    return [
-      6,
-      "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
-      "https://www.codecogs.com/eqnedit.php?latex=",
-      "%5Cinline%20",
-      "",
-      "Codecogs",
-      "%5Cdpi%7B900%7D",
-    ];
-  } else if (worked == 7) {
-    return [
-      7,
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=EQUATION",
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Sciweavers",
-      "",
-    ];
-  } // here to de render legacy equations properly, don't remove without migrating to correct font!
-  else if (worked == 8) {
-    return [
-      8,
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=EQUATION",
-      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Sciweavers",
-      "",
-    ];
-  } // here to de render legacy equations properly, don't remove without migrating to correct font!
-  else if (worked == 9) {
-    return [
-      9,
-      "http://rogercortesi.com/eqn/tempimagedir/_FILENAME.png",
-      "http://rogercortesi.com/eqn/index.php?filename=_FILENAME.png&outtype=png&bgcolor=white&txcolor=black&res=1800&transparent=1&antialias=0&latextext=",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Roger's renderer",
-      "",
-    ];
-  } //Filename has to not have any +, Avoid %,Instead use†‰, avoid And specific ASCII Percent codes
-  else if (worked == 10) {
-    return [10, "https://texrendr.com/cgi-bin/mathtex.cgi?%5Cdpi%7B1800%7DEQUATION", "https://www.texrendr.com/?eqn=", "%5Ctextstyle%20", "", "Texrendr", ""];
-  } // here to de render legacy equations properly,  //http://rogercortesi.com/eqn/index.php?filename=tempimagedir%2Feqn3609.png&outtype=png&bgcolor=white&txcolor=black&res=900&transparent=1&antialias=1&latextext=  //removed %5Cdpi%7B900%7D
-  else if (worked == 11) {
-    return [
-      11,
-      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=EQUATION",
-      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Sciweavers_old",
-      "",
-    ];
-  } // here to de render legacy equations properly, don't remove without migrating to correct font!
-  else if (worked == 12) {
-    return [
-      12,
-      "http://latex.numberempire.com/render?EQUATION&sig=41279378deef11cbe78026063306e50d",
-      "http://latex.numberempire.com/render?",
-      "%5Ctextstyle%20%7B",
-      "%7D",
-      "Number empire",
-      "",
-    ];
-  } // to de render possibly very old equations
-  else
-    return [13, "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION", "https://www.codecogs.com/eqnedit.php?latex=", "%5Cinline%20", "", "Codecogs", "%5Cdpi%7B900%7D"];
+  // for worked >= 6, renderers are static
+  if (worked >= 6) {
+    return otherRenderers[worked - 6];
+  }
+
+  // if codecogs is slow, use sciweaver/texrendr before it
+  const renderers = codecogsSlow ?
+    [sciWeaverRenderer, texRendrRenderer, ...codeCogsRenderers] :
+    [...codeCogsRenderers, texRendrRenderer, sciWeaverRenderer];
+
+  return renderers[worked - 1];
 }
 
 /**
@@ -607,23 +609,22 @@ function getSize(sizeRaw: string) {
  * @public
  */
 function derenderEquation(origURL: string) {
-  let worked = 1;
-  let found = 0;
-  let renderer: string[] = [];
-  for (; worked <= capableDerenderers; ++worked) {
+  let found = false;
+  for (let worked = 1; worked <= capableDerenderers; ++worked) {
     //[3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
-    renderer = getRenderer(worked)[2].split("FILENAME"); //list of possibly more than one string
-    for (let I = 0; I < renderer.length; ++I) {
-      if (origURL.indexOf(renderer[I]) > -1) {
-        debugLog("Changing: " + origURL + " by removing " + renderer[I]);
-        origURL = origURL.substring(origURL.indexOf(renderer[I])).split(renderer[I]).join(""); //removes prefix
-        found = 1;
-        debugLog("Next check: " + origURL + " for " + renderer[I + 1]);
-      } else break;
+    const renderer = getRenderer(worked).editor.split("FILENAME"); //list of possibly more than one string
+    for (const item of renderer) {
+      const itemIndex = origURL.indexOf(item);
+
+      if (itemIndex === -1) break;
+      
+      debugLog(`Changing: ${origURL} by removing ${item}`);
+      origURL = origURL.substring(itemIndex + item.length); //removes prefix
+      found = true;
     }
   }
-  if (found == 0) {
-    console.log("Not an equation link! " + origURL, origURL.indexOf(renderer[0]), origURL.indexOf(renderer[1]));
+  if (!found) {
+    console.log("Not an equation link! " + origURL);
     return null; // not an equation link
   }
   const last2 = origURL.slice(-2);

--- a/Common/mathjax/build.mjs
+++ b/Common/mathjax/build.mjs
@@ -1,0 +1,15 @@
+import { build } from "esbuild";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [join(dir, "mathjax.ts")],
+  bundle: true,
+  minify: true,
+  target: "es2015",
+  outfile: join(dir, "../MathJax.js"),
+  format: "iife",
+  platform: "neutral"
+});

--- a/Common/mathjax/mathjax.ts
+++ b/Common/mathjax/mathjax.ts
@@ -1,0 +1,35 @@
+// adapted from https://github.com/mathjax/MathJax-demos-node/blob/master/direct/tex2svg
+
+import { mathjax } from "mathjax-full/js/mathjax";
+import { TeX } from "mathjax-full/js/input/tex";
+import { SVG } from "mathjax-full/js/output/svg";
+import { liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor";
+import { RegisterHTMLHandler } from "mathjax-full/js/handlers/html";
+import { AllPackages } from "mathjax-full/js/input/tex/AllPackages";
+
+const mathCss = `
+svg a { fill: blue; stroke: blue; }
+[data-mml-node="merror"] > g { fill: red; stroke: red; }
+[data-mml-node="merror"] > rect[data-background] { fill: yellow; stroke: yellow; }
+[data-frame], [data-line] { stroke-width: 70px; fill: none; }
+.mjx-dashed { stroke-dasharray: 140; }
+.mjx-dotted { stroke-linecap: round; stroke-dasharray: 0, 140; }
+use[data-c] { stroke-width: 3px; }
+`;
+
+const adaptor = liteAdaptor();
+RegisterHTMLHandler(adaptor);
+const tex = new TeX({ packages: AllPackages });
+const svg = new SVG({ fontCache: "local" });
+const html = mathjax.document("", { InputJax: tex, OutputJax: svg });
+
+globalThis.renderMathjaxEquation = (equation: string, inline: boolean) => {
+  const node = html.convert(equation, {
+    display: !inline,
+    em: 16,
+    ex: 8,
+    containerWidth: 80 * 16
+  });
+
+  return adaptor.innerHTML(node);
+};

--- a/Common/package.json
+++ b/Common/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "main": "Code.js",
-  "author": "",
-  "license": "ISC",
   "scripts": {
+    "build-mathjax": "node mathjax/build.mjs",
     "build-types": "clasp-types -o ../types -p AutoLatexCommon -n Common"
+  },
+  "dependencies": {
+    "esbuild": "^0.23.0",
+    "mathjax-full": "^3.2.2"
   }
 }

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -6,6 +6,18 @@
 /* exported onOpen, showSidebar, replaceEquations */
 
 var DEBUG = false; //doing ctrl + m to get key to see errors is still needed; DEBUG is for all nondiagnostic information
+// number of tries to insert the equation image
+const INSERT_IMAGE_TRIES = 2;
+// number of tries to set the link on the image
+const SET_IMAGE_LINK_TRIES = 3;
+// image scale divisors for each renderer
+const IMAGE_SCALE_DIVISORS = {
+  "Texrendr": 42.0,
+  "Roger's renderer": 200.0,
+  "Codecogs": 100.0,
+  "Sciweavers": 98.0,
+  "Sciweavers_old": 76.0
+};
 
 const DocsApp = {
 	getUi: function(){
@@ -246,63 +258,56 @@ function placeImage(startElement: GoogleAppsScript.Document.RangeElement, start:
     return [defaultSize, startElement];
   }
 
-  let { resp, renderer, rendererType, worked, equation } = Common.renderEquation(equationOriginal, quality, delim, isInline, 0, 0, 0); 
-  if (worked > Common.capableRenderers) return [-100000, null];
+  const renderResult = Common.renderEquation(equationOriginal, quality, delim, isInline, 0, 0, 0); 
+  if (!renderResult) return [-100000, null];
+  const { imageBlob, renderer, editorOriginalEqUrl, isCodecogsError } = renderResult;
+  
   // SAVING FORMATTING
   Common.reportDeltaTime(511);
-  if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == Common.invalidEquationHashCodecogsFirst50) {
-    worked = 1; //assumes codecogs is 1
-    renderer = Common.getRenderer(worked);
-    rendererType = renderer[5];
-  }
-  Common.reportDeltaTime(517);
   const textCopy = textElement.asText().copy();
   let endLimit = end;
   if (text.length - 1 < endLimit) endLimit = text.length - 1;
   textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
   Common.reportDeltaTime(522);
   textElement.editAsText().deleteText(start, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
-  const logoBlob = resp.getBlob();
   Common.reportDeltaTime(526);
 
-  try {
-    paragraph.insertInlineImage(childIndex + 1, logoBlob); // TODO ISSUE: sometimes fails because it times out and yeets
-    const returnParams = repairImage(paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal);
-    return returnParams;
-  } catch (err) {
-    console.log("Could not insert image try 1");
-    console.error(err);
+  for (let i = 0; i < INSERT_IMAGE_TRIES; i++) {
+    try {
+      paragraph.insertInlineImage(childIndex + 1, imageBlob); // TODO ISSUE: sometimes fails because it times out and yeets
+      const returnParams = repairImage(paragraph, childIndex, size, defaultSize, renderer, textCopy, editorOriginalEqUrl, isCodecogsError);
+      return returnParams;
+    } catch (err) {
+      console.log(`Could not insert image try ${i + 1}`);
+      console.error(err);
+
+      // wait 1 second before trying again
+      Utilities.sleep(1000);
+    }
   }
-  Common.reportDeltaTime(536);
-  try {
-    Utilities.sleep(1000);
-    paragraph.insertInlineImage(childIndex + 1, logoBlob); // TODO ISSUE: sometimes fails because it times out and yeets
-    const returnParams = repairImage(paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal);
-    return returnParams;
-  } catch (err) {
-    console.log("Could not insert image try 2 after 1000ms");
-    console.error(err);
-  }
+
   throw new Error("Could not insert image at childindex!");
 }
 
-function repairImage(paragraph: GoogleAppsScript.Document.Paragraph, childIndex: number, size:  number, defaultSize: number, renderer: AutoLatexCommon.Renderer, delim: AutoLatexCommon.Delimiter, textCopy: GoogleAppsScript.Document.Text, resp: GoogleAppsScript.URL_Fetch.HTTPResponse, rendererType: string, equation: string, equationOriginal: string): [number, null] {
-  let attemptsToSetImageUrl = 3;
+function repairImage(paragraph: GoogleAppsScript.Document.Paragraph, childIndex: number, size:  number, defaultSize: number, renderer: AutoLatexCommon.Renderer, textCopy: GoogleAppsScript.Document.Text, editorOriginalEqUrl: string, isCodecogsError: boolean): [number, null] {
   Common.reportDeltaTime(552); // 3 seconds!! inserting an inline image takes time
-  while (attemptsToSetImageUrl > 0) {
+
+  // try to set the link on the image (with the derendering info)
+  for (let i = 0; i < SET_IMAGE_LINK_TRIES; i++) {
     try {
-      paragraph.getChild(childIndex + 1).asInlineImage().setLinkUrl(renderer[2] + equationOriginal + "#" + delim[6]); //added % delim 6 to keep track of which delimiter was used to render
+      paragraph.getChild(childIndex + 1).asInlineImage().setLinkUrl(editorOriginalEqUrl); //added % delim 6 to keep track of which delimiter was used to render
+
+      if (i > 0) {
+        console.log(`At ${i + 1} attemptsToSetImageUrls of failing to get child and link, ${editorOriginalEqUrl}`);
+      }
       break;
     } catch (err) {
       console.log("Couldn't insert child index!");
       console.log("Next child not found!");
-      --attemptsToSetImageUrl;
-    }
-  }
-  if (attemptsToSetImageUrl < 3) {
-    console.log("At ", attemptsToSetImageUrl, " attemptsToSetImageUrls of failing to get child and link , ", equation);
-    if (attemptsToSetImageUrl == 0) {
-      throw new Error("Couldn't get equation child!"); // of image immediately after inserting
+
+      if (i === SET_IMAGE_LINK_TRIES - 1) {
+        throw new Error("Couldn't get equation child!"); // of image immediately after inserting
+      }
     }
   }
 
@@ -315,32 +320,15 @@ function repairImage(paragraph: GoogleAppsScript.Document.Paragraph, childIndex:
   //SET PROPERTIES OF IMAGE (Height, Width)
   const oldSize = size; // why use oldsize instead of new size
 
-  if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == Common.invalidEquationHashCodecogsFirst50 || (size > 10 && width == 126 && height == 24)) {
+  if (isCodecogsError || (size > 10 && width == 126 && height == 24)) {
     size *= 5; // make codecogs errors readable, size constraint just in case some small equation is 126x24 as well
   }
-  // console.log(rendererType, rendererType.valueOf(), "Texrendr".valueOf(), rendererType.valueOf() === "Codecogs".valueOf(), rendererType.valueOf() == "Codecogs".valueOf(), rendererType === "Codecogs", rendererType.valueOf() === "Texrendr".valueOf(), rendererType.valueOf() == "Texrendr".valueOf(), rendererType === "Texrendr")
-  // note that valueOf here is not needed, and neither is === => removing both keeps trues true and falses false in V8.
+  
 
   // if(rendererType.valueOf() === "Texrendr".valueOf())  //Old TexRendr
   // 	size = Math.round(size * height / 174);
-  let multiple = size / 100.0;
-  if (rendererType.valueOf() === "Texrendr".valueOf())
-    //TexRendr
-    multiple = size / 42.0;
-  else if (rendererType.valueOf() === "Roger's renderer".valueOf())
-    //Rogers renderer
-    multiple = size / 200.0;
-  else if (rendererType.valueOf() === "Codecogs".valueOf())
-    //CodeCogs, other
-    multiple = size / 100.0;
-  else if (rendererType.valueOf() === "Sciweavers".valueOf())
-    //Scieweavers
-    multiple = size / 98.0;
-  else if (rendererType.valueOf() === "Sciweavers_old".valueOf())
-    //C [75.4, 79.6] on width and height ratio
-    multiple = size / 76.0;
-  //CodeCogs, other
-  else multiple = size / 100.0;
+
+  const multiple = size / (IMAGE_SCALE_DIVISORS[renderer.name] ?? 100.0);
 
   size = Math.round(height * multiple);
   Common.reportDeltaTime(595);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "autolatex",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "workspaces": [
         "Common",
         "Docs",
@@ -28,7 +28,11 @@
     "Common": {
       "name": "common",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "esbuild": "^0.23.0",
+        "mathjax-full": "^3.2.2"
+      }
     },
     "Docs": {
       "name": "docs",
@@ -97,6 +101,390 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
+      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
+      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
+      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
+      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
+      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
+      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
+      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
+      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
+      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
+      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
+      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
+      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
+      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
+      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -794,6 +1182,45 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
+      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.0",
+        "@esbuild/android-arm": "0.23.0",
+        "@esbuild/android-arm64": "0.23.0",
+        "@esbuild/android-x64": "0.23.0",
+        "@esbuild/darwin-arm64": "0.23.0",
+        "@esbuild/darwin-x64": "0.23.0",
+        "@esbuild/freebsd-arm64": "0.23.0",
+        "@esbuild/freebsd-x64": "0.23.0",
+        "@esbuild/linux-arm": "0.23.0",
+        "@esbuild/linux-arm64": "0.23.0",
+        "@esbuild/linux-ia32": "0.23.0",
+        "@esbuild/linux-loong64": "0.23.0",
+        "@esbuild/linux-mips64el": "0.23.0",
+        "@esbuild/linux-ppc64": "0.23.0",
+        "@esbuild/linux-riscv64": "0.23.0",
+        "@esbuild/linux-s390x": "0.23.0",
+        "@esbuild/linux-x64": "0.23.0",
+        "@esbuild/netbsd-x64": "0.23.0",
+        "@esbuild/openbsd-arm64": "0.23.0",
+        "@esbuild/openbsd-x64": "0.23.0",
+        "@esbuild/sunos-x64": "0.23.0",
+        "@esbuild/win32-arm64": "0.23.0",
+        "@esbuild/win32-ia32": "0.23.0",
+        "@esbuild/win32-x64": "0.23.0"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -919,6 +1346,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -1431,6 +1867,18 @@
         "node": ">= 12"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1439,6 +1887,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -1464,6 +1918,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1796,6 +2256,29 @@
       "resolved": "Slides",
       "link": true
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2063,6 +2546,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
+    },
     "node_modules/workspace": {
       "resolved": "Workspace",
       "link": true
@@ -2072,6 +2561,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
+      "license": "(LGPL-2.0 or MIT)",
+      "engines": {
+        "node": ">=0.1"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -2141,6 +2639,150 @@
           "dev": true
         }
       }
+    },
+    "@esbuild/aix-ppc64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
+      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
+      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
+      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
+      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
+      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
+      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
+      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
+      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
+      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
+      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
+      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
+      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
+      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
+      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
+      "optional": true
     },
     "@eslint-community/eslint-utils": {
       "version": "4.2.0",
@@ -2569,7 +3211,11 @@
       "dev": true
     },
     "common": {
-      "version": "file:Common"
+      "version": "file:Common",
+      "requires": {
+        "esbuild": "^0.23.0",
+        "mathjax-full": "^3.2.2"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2637,6 +3283,37 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
+      }
+    },
+    "esbuild": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
+      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "requires": {
+        "@esbuild/aix-ppc64": "0.23.0",
+        "@esbuild/android-arm": "0.23.0",
+        "@esbuild/android-arm64": "0.23.0",
+        "@esbuild/android-x64": "0.23.0",
+        "@esbuild/darwin-arm64": "0.23.0",
+        "@esbuild/darwin-x64": "0.23.0",
+        "@esbuild/freebsd-arm64": "0.23.0",
+        "@esbuild/freebsd-x64": "0.23.0",
+        "@esbuild/linux-arm": "0.23.0",
+        "@esbuild/linux-arm64": "0.23.0",
+        "@esbuild/linux-ia32": "0.23.0",
+        "@esbuild/linux-loong64": "0.23.0",
+        "@esbuild/linux-mips64el": "0.23.0",
+        "@esbuild/linux-ppc64": "0.23.0",
+        "@esbuild/linux-riscv64": "0.23.0",
+        "@esbuild/linux-s390x": "0.23.0",
+        "@esbuild/linux-x64": "0.23.0",
+        "@esbuild/netbsd-x64": "0.23.0",
+        "@esbuild/openbsd-arm64": "0.23.0",
+        "@esbuild/openbsd-x64": "0.23.0",
+        "@esbuild/sunos-x64": "0.23.0",
+        "@esbuild/win32-arm64": "0.23.0",
+        "@esbuild/win32-ia32": "0.23.0",
+        "@esbuild/win32-x64": "0.23.0"
       }
     },
     "escape-string-regexp": {
@@ -2732,6 +3409,11 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "espree": {
       "version": "7.3.1",
@@ -3137,11 +3819,27 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
+    "mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
+    },
+    "mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -3161,6 +3859,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -3384,6 +4087,23 @@
     "slides": {
       "version": "file:Slides"
     },
+    "speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "requires": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+          "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3584,6 +4304,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
+    },
     "workspace": {
       "version": "file:Workspace"
     },
@@ -3592,6 +4317,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "autolatex",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "ISC",
       "workspaces": [
         "Common",
         "Docs",
@@ -28,7 +28,6 @@
     "Common": {
       "name": "common",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "esbuild": "^0.23.0",
         "mathjax-full": "^3.2.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,6 @@
     "experimentalDecorators": true,
     "module": "CommonJS",
     "target": "ES5",
-    "lib": ["ES6", "ES2016", "ES2017", "ES2018"]
+    "lib": ["ES6", "ES2016", "ES2017", "ES2018", "ES2019", "ES2020", "ES2021"]
   }
 }

--- a/types/common-types/LICENSE
+++ b/types/common-types/LICENSE
@@ -1,7 +1,7 @@
 
 MIT License
 
-Copyright (c) 2023 
+Copyright (c) 2024 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for Common
 // Generated using clasp-types
 
+/// <reference types="esbuild" />
+
+/// <reference types="mathjax-full" />
+
 declare namespace AutoLatexCommon {
 
     /**
@@ -42,7 +46,7 @@ declare namespace AutoLatexCommon {
          */
         reEncode(equation: string): string;
 
-        renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): {equation: string, renderer: Renderer, rendererType: string, resp: GoogleAppsScript.URL_Fetch.HTTPResponse, worked: number};
+        renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): {editorOriginalEqUrl: string, equation: string, imageBlob: GoogleAppsScript.Base.Blob, isCodecogsError: boolean, renderer: Renderer};
 
         reportDeltaTime(line?: number, forcePrint?: string): number;
 
@@ -57,7 +61,7 @@ declare namespace AutoLatexCommon {
 
         capableRenderers: 8;
 
-        invalidEquationHashCodecogsFirst50: "GIF89a%7F%00%18%00%uFFFD%00%00%uFFFD%u0315%uFFFD3%";
+        invalidEquationHashesCodecogs: Set;
 
     }
 
@@ -98,19 +102,17 @@ declare namespace AutoLatexCommon {
      */
     export interface Renderer {
 
-        0: number;
+        editor: string;
 
-        1: string;
+        editorEnd: string;
 
-        2: string;
+        image: string;
 
-        3: string;
+        inlineEnd: string;
 
-        4: string;
+        inlineStart: string;
 
-        5: string;
-
-        6: string;
+        name: string;
 
     }
 
@@ -134,7 +136,7 @@ declare namespace AutoLatexCommon {
 
     export const capableRenderers: 8;
 
-    export const invalidEquationHashCodecogsFirst50: "GIF89a%7F%00%18%00%uFFFD%00%00%uFFFD%u0315%uFFFD3%";
+    export const invalidEquationHashesCodecogs: Set;
 
 }
 

--- a/types/common-types/package.json
+++ b/types/common-types/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "Typescript definitions for Common",
   "main": "Code.js",
-  "author": "",
-  "license": "MIT",
   "scripts": {},
+  "dependencies": {
+    "esbuild": "^0.23.0",
+    "mathjax-full": "^3.2.2"
+  },
   "devDependencies": {},
+  "license": "MIT",
   "types": "./index.d.ts"
 }


### PR DESCRIPTION
I'm not sure whether to include the MathJax bundle (`Common/MathJax.js`) in the repo -- it's 1.7 MB but it's also realistically not going to change often

Todo:
- [ ] Figure out how to add a mathjax "Renderer" 
- [ ] Add mathjax option to `renderEquation`
- [ ] Use image blob instead of URL in the individual addons
- [ ] Add option to choose a renderer instead of automatically selecting one (#13)