### PR TITLE
Fix TeXRendr rendering and add colored equation support to Docs

### DIFF
--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -204,13 +204,20 @@ function getStyle(equationStringEncoded: string, quality: number, renderer: Rend
   const equation: string[] = [];
   equationStringEncoded = equationStringEncoded;
   reportDeltaTime(307);
+  // handle RGB coloring, except on Texrendr
   if (renderer[5] !== "Texrendr") {
-    if (isInline) {
-      equationStringEncoded = renderer[3] + "%7B%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded + renderer[4] + "%7D";
-    } else {
-      equationStringEncoded = "%7B%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded + "%7D";
-    }
+    // \color[RGB]{0,0,0}
+    equationStringEncoded = "%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded;
   }
+  
+  if (isInline) {
+    // wrap in renderer inline delimiters
+    equationStringEncoded = renderer[3] + equationStringEncoded + renderer[4];
+  }
+
+  // wrap in curly braces
+  equationStringEncoded = "%7B" + equationStringEncoded + "%7D";
+
   debugLog("textColor: " + red + ", " + green + ", " + blue);
   debugLog("equationStringEncoded: " + equationStringEncoded);
   if (type === 2) {

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -209,14 +209,14 @@ function getStyle(equationStringEncoded: string, quality: number, renderer: Rend
     // \color[RGB]{0,0,0}
     equationStringEncoded = "%5Ccolor%5BRGB%5D%7B" + red + "%2C" + green + "%2C" + blue + "%7D" + equationStringEncoded;
   }
-  
+
   if (isInline) {
     // wrap in renderer inline delimiters
-    equationStringEncoded = renderer[3] + equationStringEncoded + renderer[4];
+    equationStringEncoded = renderer[3] + "%7B" + equationStringEncoded + renderer[4] + "%7D";
+  } else {
+    // just wrap in curly braces
+    equationStringEncoded = "%7B" + equationStringEncoded + "%7D";
   }
-
-  // wrap in curly braces
-  equationStringEncoded = "%7B" + equationStringEncoded + "%7D";
 
   debugLog("textColor: " + red + ", " + green + ", " + blue);
   debugLog("equationStringEncoded: " + equationStringEncoded);

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -246,7 +246,12 @@ function placeImage(startElement: GoogleAppsScript.Document.RangeElement, start:
     return [defaultSize, startElement];
   }
 
-  let { resp, renderer, rendererType, worked, equation } = Common.renderEquation(equationOriginal, quality, delim, isInline, 0, 0, 0); 
+  // get font color
+  const colorHex = textElement.getForegroundColor(start);
+  // convert to rgb
+  const [r, g, b] = [1, 3, 5].map(i => parseInt(colorHex.slice(i, i + 2), 16));
+
+  let { resp, renderer, rendererType, worked, equation } = Common.renderEquation(equationOriginal, quality, delim, isInline, r, g, b); 
   if (worked > Common.capableRenderers) return [-100000, null];
   // SAVING FORMATTING
   Common.reportDeltaTime(511);


### PR DESCRIPTION
My previous fix to the TeXRendr RGB bug actually broke inline rendering, so this fixes that.

I also added colored equation support (rather than rendering all equations in black) for other renderers.
