### PR TITLE
Common: Strip non-ascii characters before rendering

### DIFF
--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -168,6 +168,8 @@ function getFilenameEncode(equation: string, direction: number) {
  */
 function reEncode(equation: string) {
   equation = getCustomEncode(equation, 0, 1);
+  // remove non-ascii characters (but separate diacritics where possible)
+  equation = equation.normalize("NFD").replace(/[\u{0080}-\u{FFFF}]/gu, '');
   return getCustomEncode(encodeURIComponent(equation), 0, 0); //escape deprecated
 }
 


### PR DESCRIPTION
Removes characters in the unicode range 0x80-0xFFFF. Separates diacritics before doing so using `normalize()`

Fixes #36

<img width="204" height="68" alt="image" src="https://github.com/user-attachments/assets/02a45114-1b46-4146-ab73-e187bd5b51d4" />
