### PR TITLE
Support \( ... \) delimiters

### DIFF
--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -586,6 +586,9 @@ function getDelimiters(delimiters: string): Delimiter {
   if (delimiters == "$") {
     return ["$", "$", "[^\\\\]\\$", "[^\\\\]\\$", 1, 0, 2];
   } //(^|[^\\$])\$(?!\$) //(?:^|[^\\\\\\])\\\$ //[^\\\\]\\\$
+  if (delimiters == "(") {
+    return ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3];
+  }
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
 }
 
@@ -599,6 +602,9 @@ function getNumDelimiters(delimiters: string | number) {
   }
   if (delimiters == "2") {
     return "$";
+  }
+  if (delimiters == "3") {
+    return "(";
   }
   return "$$";
 }

--- a/Docs/Sidebar.html
+++ b/Docs/Sidebar.html
@@ -58,6 +58,7 @@
             <option value="$$" selected>$$ ... $$</option>
             <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value="\[">\[ ... \]</option>
+            <option value="(">\( ... \)</option>
             <!--<option value = '$'>$ ... $</option>-->
           </select>
         </div>

--- a/Sheets/Code.js
+++ b/Sheets/Code.js
@@ -910,6 +910,9 @@ function getDelimiters(delimiters) {
   if (delimiters == "$") {
     return ["$", "$", "[^\\\\]\\$", "[^\\\\]\\$", 1, 0, 2];
   } //(^|[^\\$])\$(?!\$) //(?:^|[^\\\\\\])\\\$ //[^\\\\]\\\$
+  if (delimiters == "(") {
+    return ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3];
+  }
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
 }
 
@@ -923,6 +926,9 @@ function getNumDelimiters(delimiters) {
   }
   if (delimiters == "2") {
     return "$";
+  }
+  if (delimiters == "3") {
+    return "(";
   }
   return "$$";
 }

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -58,6 +58,7 @@
           <select id = "delimit" name = "delimit">
             <option value = '$$' selected>$$ ... $$</option> <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value = '\['>\[ ... \]</option>
+            <option value = '('>\( ... \)</option>
             <!--<option value = '$'>$ ... $</option>-->
           </select>
         </div>

--- a/Slides/Sidebar.html
+++ b/Slides/Sidebar.html
@@ -58,6 +58,7 @@
             <option value="$$" selected>$$ ... $$</option>
             <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value="\[">\[ ... \]</option>
+            <option value="(">\( ... \)</option>
             <!--<option value = '$'>$ ... $</option>-->
           </select>
         </div>

--- a/autolatex_assets/code.js
+++ b/autolatex_assets/code.js
@@ -323,6 +323,7 @@ function getSize(sizeRaw){
 function getDelimiters(delimiters){// //HARDCODED DELIMTERS!!!!!!!!!!!!!
   if(delimiters=="$$"){return["$$", "$$", "\\\$\\\$", "\\\$\\\$"];}
   if(delimiters=="\["){return["\\[", "\\]", "\\\\\\[", "\\\\\\]"];}
+  if(delimiters=="("){return["\\(", "\\)", "\\\\\\(", "\\\\\\)"];}
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]"];
 }
 


### PR DESCRIPTION
## Summary
- add a new parenthesis delimiter option
- expose the new delimiter in all sidebars

## Testing
- `npm -w Common run build-types`
- `npm -w Docs run build-types`
- `npm -w Slides run build-types`


------
https://chatgpt.com/codex/tasks/task_e_68799cc5dff8832eba0c20f72f98fd95