### PR TITLE
Slides: Fix image sizing and multiline equations

### DIFF
--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -23,8 +23,10 @@ const DocsApp = {
 	getPageWidth: function() {
 		let activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
 		return activeWidth;
-	}
-};
+	},
+	// A \n in Docs represents a paragraph break, while a \r (\x0D) represents a break within a paragraph
+	newlineCharacter: "%0D"
+} satisfies AutoLatexCommon.IntegratedApp;
 
 
 /** //8.03 - De-Render, Inline, Advanced Delimiters > Fixed Inline Not Appearing
@@ -182,7 +184,7 @@ function getEquation(paragraph: GoogleAppsScript.Document.Paragraph, childIndex:
     .getText()
     .substring(start + delimiters[4], end - delimiters[4] + 1);
     Common.debugLog("See equation", equation);
-    const equationStringEncoded = Common.reEncode(equation); //escape deprecated
+    const equationStringEncoded = Common.reEncode(equation, DocsApp); //escape deprecated
   equationOriginal.push(equationStringEncoded);
   Common.reportDeltaTime(290);
   //console.log("Encoded: " + equationStringEncoded);
@@ -387,7 +389,7 @@ function removeAll(defaultDelimRaw: string) {
       }
       // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
       // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-      const result = Common.derenderEquation(origURL);
+      const result = Common.derenderEquation(origURL, DocsApp);
       if (!result) continue;
       const { origEq, delim: newDelim } = result;
       const delim = newDelim || defaultDelim;
@@ -439,7 +441,7 @@ function editEquations(sizeRaw: string, delimiter: string) {
         return Common.DerenderResult.NullUrl;
       }
       Common.debugLog("Original URL from image", origURL);
-      const result = Common.derenderEquation(origURL);
+      const result = Common.derenderEquation(origURL, DocsApp);
       if (!result) return Common.DerenderResult.InvalidUrl;
       const { delim: newDelim, origEq } = result;
       const delim = newDelim || defaultDelim;

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -346,8 +346,6 @@ function repairImage(paragraph: GoogleAppsScript.Document.Paragraph, childIndex:
   else if (rendererType.valueOf() === "Sciweavers_old".valueOf())
     //C [75.4, 79.6] on width and height ratio
     multiple = size / 76.0;
-  //CodeCogs, other
-  else multiple = size / 100.0;
 
   size = Math.round(height * multiple);
   Common.reportDeltaTime(595);

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -31,8 +31,10 @@ const IntegratedApp = {
   },
   getPageWidth: function () {
     return SlidesApp.getActivePresentation().getPageWidth();
-  }
-};
+  },
+  // Shift-enter in slides produces \x0B, or \v
+  newlineCharacter: "%0B"
+} satisfies AutoLatexCommon.IntegratedApp;
 
 
 /** //8.03 - De-Render, Inline, Advanced Delimiters > Fixed Inline Not Appearing
@@ -334,7 +336,7 @@ function getEquation(paragraph: GoogleAppsScript.Slides.TextRange, start: number
   Common.debugLog("getEquation- " + equation.length);
   Common.debugLog("checkForEquation- " + checkForEquation.length);
 
-  var equationStringEncoded = Common.reEncode(equation); //escape deprecated
+  var equationStringEncoded = Common.reEncode(equation, IntegratedApp); //escape deprecated
   equationOriginal.push(equationStringEncoded);
   return equationStringEncoded;
 }
@@ -555,7 +557,7 @@ function derenderImage(image: GoogleAppsScript.Slides.Image, defaultDelim: AutoL
   if (!origURL) return Common.DerenderResult.NullUrl;
 
   Common.debugLog("Original URL from image", origURL);
-  const result = Common.derenderEquation(origURL);
+  const result = Common.derenderEquation(origURL, IntegratedApp);
   if (!result) return Common.DerenderResult.InvalidUrl;
   const { delim: newDelim, origEq } = result;
   const delim = newDelim || defaultDelim;

--- a/types/common-types/LICENSE
+++ b/types/common-types/LICENSE
@@ -1,7 +1,7 @@
 
 MIT License
 
-Copyright (c) 2023 
+Copyright (c) 2025 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -14,7 +14,7 @@ declare namespace AutoLatexCommon {
 
         debugLog(...strings: any[]): void;
 
-        derenderEquation(origURL: string): {delim: Delimiter, origEq: string};
+        derenderEquation(origURL: string, app: IntegratedApp): {delim: Delimiter, origEq: string};
 
         encodeFlag(flag: number, renderCount: number): number;
 
@@ -40,7 +40,7 @@ declare namespace AutoLatexCommon {
         /**
          * Retrives the equation from the paragraph, encodes it, and returns it.
          */
-        reEncode(equation: string): string;
+        reEncode(equation: string, app: IntegratedApp): string;
 
         renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): {equation: string, renderer: Renderer, rendererType: string, resp: GoogleAppsScript.URL_Fetch.HTTPResponse, worked: number};
 
@@ -80,6 +80,8 @@ declare namespace AutoLatexCommon {
     }
 
     export interface IntegratedApp {
+
+        newlineCharacter: string;
 
         getActive(): (GoogleAppsScript.Document.Document | GoogleAppsScript.Slides.Presentation);
 


### PR DESCRIPTION
This fixes the rendering and derendering of multiline equations in Slides by processing \v (\x0B) instead of \r (\x0D).

This also fixes image sizing to match Docs's algorithm, which scales the image provided by the renderer based on the required size (and a constant for each renderer).

Previously, the height of the rendered image was calculated solely based on the size and some constants (ignoring the original image height from the renderer). This makes equations with tall symbols render very small.

<img width="829" height="248" alt="image" src="https://github.com/user-attachments/assets/f194ee8b-e3f6-491c-af5a-a1fe309ff2bd" />

The old render on the right is what's currently on the test slide deck. It's slightly smaller than what this PR renders, but I think the new render matches the size of the actual text better.