### PR TITLE
feat: auto mode fallback Codecogs > MathJax > Texrendr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 Slides/Sidebar.js
 Docs/Sidebar.js
 SidebarJS.html
+Common/Code.js
+Common/Unicode.js
+Docs/Code.js
+Slides/Code.js
+Workspace/Code.js
+Workspace/Docs.js
+Workspace/Sheets.js

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Slides/Code.js
 Workspace/Code.js
 Workspace/Docs.js
 Workspace/Sheets.js
+.env
+.env.*
+!.env.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Repo Instructions
+
+When asked to push or deploy this repo's Google Apps Script projects, first read [skills/apps-script-push/SKILL.md](/Users/aayushgupta/Documents/.projects.nosync/autolatex/skills/apps-script-push/SKILL.md).
+
+Use that skill for:
+
+- pushing `Common`, `Docs`, `Slides`, or `Workspace`
+- handling `clasp` library-linking issues
+- rebuilding Docs or Slides sidebars before a push
+- distinguishing project head pushes from versioned deployment updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Code Instructions
+
+Before pushing or deploying any Google Apps Script project in this repo, read [skills/apps-script-push/SKILL.md](/Users/aayushgupta/Documents/.projects.nosync/autolatex/skills/apps-script-push/SKILL.md).
+
+Follow that file for:
+
+- the correct `clasp` command for each project
+- when to use `npm run clasp-push` instead of raw `clasp push`
+- Docs and Slides sidebar rebuild requirements
+- post-push verification
+- the difference between project head and versioned deployments

--- a/Common/Code.js
+++ b/Common/Code.js
@@ -333,8 +333,9 @@ function getPrefs() {
  * @public
  */
 function getKey() {
-    console.log("Got Key: " + Session.getTemporaryActiveUserKey() + " and email " + Session.getEffectiveUser().getEmail());
-    return Session.getTemporaryActiveUserKey();
+    var key = Session.getTemporaryActiveUserKey();
+    console.log("Got Key: " + key);
+    return key;
 }
 /**
  * @public

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -53,6 +53,15 @@ interface LegacyRenderArgs {
   blue: number;
 }
 
+interface RenderEquationResult {
+  resp: GoogleAppsScript.URL_Fetch.HTTPResponse | null;
+  renderer: Renderer | null;
+  rendererType: string;
+  worked: number;
+  equation: string;
+  authorizationError?: boolean;
+}
+
 /**
 * Options/state for rendering on the client - these are settings for a specific equation
 * 
@@ -475,7 +484,7 @@ function renderEquation(
   legacyRed?: number,
   legacyGreen?: number,
   legacyBlue?: number
-) {
+): RenderEquationResult {
   const renderOptions = normalizeRenderEquationArgs(
     renderOptionsOrQuality,
     legacyDelim,
@@ -495,6 +504,7 @@ function renderEquation(
   let failedCodecogs = 0;
   let failedTexrendr = 0;
   let failedResp: GoogleAppsScript.URL_Fetch.HTTPResponse | null = null;
+  let authorizationError = false;
   // if only failed codecogs, probably weird evening bug from 10/15/19
   // if failed codecogs and texrendr, probably shitty equation and the codecogs error is more descriptive so show it
 
@@ -600,6 +610,9 @@ function renderEquation(
       console.log("Worked with renderer ", worked, " and type ", rendererType);
       break;
     } catch (err) {
+      if (isUrlFetchAuthorizationError(err)) {
+        authorizationError = true;
+      }
       console.log(rendererType + " Error! - " + err);
       const failedEquationLinkLength = renderer ? renderer[1].length : -1;
       deltaTime = reportDeltaTime(533, " failed equation link length " + failedEquationLinkLength + " and renderer  " + rendererType);
@@ -621,8 +634,15 @@ function renderEquation(
     renderer,
     rendererType,
     worked,
-    equation
+    equation,
+    authorizationError
   }
+}
+
+function isUrlFetchAuthorizationError(err: unknown) {
+  const message = String(err || "");
+  return message.indexOf("You do not have permission to call UrlFetchApp.fetch") !== -1 ||
+    message.indexOf("script.external_request") !== -1;
 }
 
 /**

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -35,6 +35,13 @@ interface RenderOptions extends CommonRenderOptions {
   // The default/previous size of the text, in case size is null.
   defaultSize: number;
   clientRender: boolean;
+  // REASON: When true, Codecogs is tried server-side first in auto mode.
+  // If Codecogs fails, the equation is sent to the client for MathJax rendering.
+  // This enables the fallback order: Codecogs -> MathJax (client) -> Texrendr/Sciweavers.
+  autoFallbackToClient?: boolean;
+  // REASON: When set, only server-side renderers whose family name is in this list will be attempted.
+  // Used to implement staged fallback: first try Codecogs only, then Texrendr/Sciweavers only.
+  allowedServerFamilies?: string[];
 }
 
 interface LegacyRenderArgs {
@@ -452,8 +459,9 @@ function getPrefs() {
  * @public
  */
 function getKey() {
-  console.log("Got Key: " + Session.getTemporaryActiveUserKey() + " and email " + Session.getEffectiveUser().getEmail());
-  return Session.getTemporaryActiveUserKey();
+  const key = Session.getTemporaryActiveUserKey();
+  console.log("Got Key: " + key);
+  return key;
 }
 
 /**
@@ -490,7 +498,17 @@ function renderEquation(
   // if only failed codecogs, probably weird evening bug from 10/15/19
   // if failed codecogs and texrendr, probably shitty equation and the codecogs error is more descriptive so show it
 
-  for (const rendererIndex of getRendererOrder()) {
+  // REASON: allowedServerFamilies restricts which server renderers are attempted in this call.
+  // In auto mode, the first pass tries only Codecogs; the fallback pass tries Texrendr/Sciweavers.
+  let rendererOrder = getRendererOrder();
+  if (renderOptions.allowedServerFamilies) {
+    rendererOrder = rendererOrder.filter(idx => {
+      const family = getRenderer(idx)[5];
+      return renderOptions.allowedServerFamilies!.includes(family);
+    });
+  }
+
+  for (const rendererIndex of rendererOrder) {
     worked = rendererIndex;
     //[3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
     try {

--- a/Common/package.json
+++ b/Common/package.json
@@ -6,6 +6,8 @@
   "author": "",
   "license": "ISC",
   "scripts": {
+    "preclasp-push": "node ../BuildSidebarJS.js",
+    "clasp-push": "clasp push",
     "build-types": "clasp-types -o ../types -p AutoLatexCommon -n Common"
   }
 }

--- a/Docs/.claspignore
+++ b/Docs/.claspignore
@@ -1,2 +1,3 @@
 Sidebar.js
 Sidebar.ts
+testtmp.html

--- a/Docs/ALEStylesheet.html
+++ b/Docs/ALEStylesheet.html
@@ -122,6 +122,56 @@
     color: #b3261e;
   }
 
+  /* Per-equation failure list shown inside .ale-error when the server reports
+     specific equations it couldn't render or auto-fix. */
+  .ale-failure-list {
+    margin-top: 8px;
+    color: #5f3939;
+  }
+
+  .ale-failure-list ul {
+    margin: 4px 0 0 16px;
+    padding: 0;
+  }
+
+  .ale-failure-list li {
+    margin-bottom: 6px;
+  }
+
+  .ale-failure-list code {
+    background: #f6e8e7;
+    border: 1px solid #e3c2c0;
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 11px;
+    word-break: break-all;
+  }
+
+  .ale-error-hint {
+    color: #5f3939;
+    font-size: 11px;
+    display: block;
+    margin-top: 2px;
+  }
+
+  .ale-error-more {
+    margin-top: 6px;
+    font-style: italic;
+    font-size: 11px;
+  }
+
+  /* Soft note shown after a successful render when we silently auto-fixed
+     a multiline equation. Not styled as an error - just an FYI to the user. */
+  .ale-autofix-note {
+    margin-top: 6px;
+    padding: 6px 8px;
+    background: #e8f0fe;
+    border-left: 3px solid #4285f4;
+    color: #1a73e8;
+    font-size: 11px;
+    border-radius: 2px;
+  }
+
   .sidebar-content {
     padding-bottom: 112px;
   }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -277,12 +277,18 @@ function isSingleDollarDelimiter(rangeElement) {
     }
     return true;
 }
-function findNextDelimiter(docBody, renderOptions, fromRange) {
+// REASON: delimIdx picks delim[2] (start regex) vs delim[3] (end regex).
+// For asymmetric delimiters like `\[ ... \]` and `\( ... \)` the start and end patterns differ,
+// so using delim[2] for both (the original bug) caused the end-search to look for another `\[`
+// instead of `\]`, find none, and report "no equations found." For `$ ... $` the two are the
+// same regex so either index works; isSingleDollarDelimiter still filters out `$$` / `\$` cases.
+function findNextDelimiter(docBody, renderOptions, fromRange, delimIdx) {
     if (fromRange === void 0) { fromRange = null; }
+    if (delimIdx === void 0) { delimIdx = 2; }
     if (renderOptions.delim[6] !== 2) {
         return fromRange == null
-            ? docBody.findText(renderOptions.delim[2])
-            : docBody.findText(renderOptions.delim[2], fromRange);
+            ? docBody.findText(renderOptions.delim[delimIdx])
+            : docBody.findText(renderOptions.delim[delimIdx], fromRange);
     }
     var candidate = fromRange == null ? docBody.findText("\\$") : docBody.findText("\\$", fromRange);
     while (candidate != null) {
@@ -409,14 +415,14 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
             status: 5 /* DocsEquationRenderStatus.NoDocument */
         };
     }
-    var startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty);
+    var startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty, 2);
     if (startElement == null) {
         return {
             status: 7 /* DocsEquationRenderStatus.NoStartDelimiter */
         };
     }
     var placeHolderStart = startElement.getStartOffset(); //position of image insertion
-    var endElement = findNextDelimiter(docBody, renderOptions, startElement);
+    var endElement = findNextDelimiter(docBody, renderOptions, startElement, 3);
     // could not find the ending delimiter after the start
     if (endElement == null) {
         return {

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -348,9 +348,9 @@ function getContainingTopLevelChild(element, body) {
 // What breaks if removed: every multiline equation entered with Enter raises a "End index N
 // must be >= start index M" exception in findPos and the user gets a useless generic error.
 //
-// Limitations: any rich formatting (bold/italic/font/color) on text inside the merged
-// paragraphs is collapsed because appendText only takes a string. We accept that loss because
-// the merged region is the equation itself, which gets replaced by an image anyway.
+// Limitations: rich formatting inside paragraphs that are moved during this auto-fix is not
+// preserved because appendText only takes a string. Formatting is not the failure condition;
+// the paragraph break is.
 function tryAutoMergeMultiParagraphEquation(body, startParaIdx, endParaIdx) {
     if (endParaIdx <= startParaIdx) {
         return { success: false, reason: "Paragraph indices out of order" };
@@ -382,7 +382,7 @@ function tryAutoMergeMultiParagraphEquation(body, startParaIdx, endParaIdx) {
         var text = nextPara.getText();
         // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
         // See newlineCharacter comment near top of this file.
-        startPara.appendText("\r" + text);
+        startPara.editAsText().appendText("\r" + text);
         nextPara.removeFromParent();
     }
     return { success: true, reason: "Merged " + numToMerge + " paragraph(s) with line breaks" };
@@ -485,8 +485,8 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
             }
         };
     }
-    // Same top-level container but possibly different Text children (e.g., split by inline
-    // image or formatting boundary). Detect by trying the addElement build under a try/catch
+    // Same top-level container but possibly different Text children. Detect by trying
+    // the addElement build under a try/catch
     // so we don't have to fragile-compare element references.
     // REASON: We deliberately wrap *only* the range build in try/catch, not the downstream
     // findEquationAndPlaceImage call. Catching findEquationAndPlaceImage failures here would
@@ -521,7 +521,7 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
                 snippet: snippet || "(unknown)",
                 hint: isStaleOffset
                     ? "This equation could not be located after a prior render. Try clicking 'Render Equations' again — it usually works on the second try."
-                    : "This equation appears to cross a formatting boundary or an inline element. Try removing any formatting changes (bold, italic, font, color) inside the $$ delimiters, or remove inline images from the equation."
+                    : "This equation appears to contain a paragraph break inside the delimiters. Use Shift+Enter instead of Enter for line breaks inside an equation."
             }
         };
     }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -116,6 +116,8 @@ function replaceEquations(sizeRaw, delimiter, renderer) {
     if (renderer === void 0) { renderer = "auto"; }
     var quality = 900;
     var clientRender = renderer === "mathjax";
+    // REASON: In auto mode, try Codecogs server-side first, then MathJax on client, then Texrendr/Sciweavers.
+    var autoFallbackToClient = renderer === "auto";
     if (clientRender) {
         console.log("MathJax render requested.", JSON.stringify({ sizeRaw: sizeRaw, delimiter: delimiter }));
     }
@@ -138,35 +140,57 @@ function replaceEquations(sizeRaw, delimiter, renderer) {
     catch (error) {
         console.error(error);
         return {
-            lastStatus: 3 /* DocsEquationRenderStatus.NoDocument */,
-            successCount: 0
+            lastStatus: 5 /* DocsEquationRenderStatus.NoDocument */,
+            successCount: 0,
+            autoFixedCount: 0,
+            failureDetails: []
         };
     }
+    // REASON: Collect every equation we couldn't render so we can return them all to the sidebar
+    // in a single response, instead of dying on the first error and hiding the rest from the user.
+    var failureDetails = [];
+    // REASON: Count of equations we silently auto-recovered (e.g. merged paragraph-split equations).
+    // Surfaced in the sidebar so the user knows we changed their doc on their behalf.
+    var autoFixedCount = 0;
     var baseRenderOptions = {
         size: size,
         defaultSize: 11,
         inline: isInline,
         delim: delim,
         clientRender: clientRender,
+        autoFallbackToClient: autoFallbackToClient,
         // TODO: color support for Docs
         r: 0,
         g: 0,
         b: 0
     };
+    // REASON: Collect equations that need client-side MathJax rendering instead of returning
+    // on the first one. This allows Codecogs to batch-process all equations it can handle,
+    // then send ALL remaining failures to the client for parallel MathJax rendering.
+    var clientRenderBatch = [];
     var childCount = body.getBody().getParent().getNumChildren();
     Common.reportDeltaTime(156);
     for (var index = 0; index < childCount; index++) {
         var failedStartElemIfIsEmpty = null;
         while (true) {
             // prevFailedStartElemIfIsEmpty is here so when $$$$ fails again and again, it doesn't get stuck there and moves on.
-            var _a = findPos(index, baseRenderOptions, failedStartElemIfIsEmpty), status_1 = _a.status, equationSize = _a.equationSize, nextStartElement = _a.nextStartElement, clientRenderOptions = _a.clientRenderOptions; //or: "\\\$\\\$", "\\\$\\\$"
+            var findPosResult = findPos(index, baseRenderOptions, failedStartElemIfIsEmpty); //or: "\\\$\\\$", "\\\$\\\$"
+            var status_1 = findPosResult.status, equationSize = findPosResult.equationSize, nextStartElement = findPosResult.nextStartElement, clientRenderOptions = findPosResult.clientRenderOptions, failureDetail = findPosResult.failureDetail;
             if (nextStartElement)
                 failedStartElemIfIsEmpty = nextStartElement;
             // if we found an actual equation, update the default size
             if (equationSize)
                 baseRenderOptions.defaultSize = equationSize;
+            // REASON: findPos signals an auto-fix by setting equationSize === -1 in addition to the
+            // regular status. We bump the count and re-run the same index from scratch since the doc
+            // structure changed (paragraphs merged) and any cached RangeElement is now stale.
+            if (status_1 === 8 /* DocsEquationRenderStatus.Success */ && equationSize === -1) {
+                autoFixedCount++;
+                failedStartElemIfIsEmpty = null;
+                continue;
+            }
             // count consecutive empty equations
-            if (status_1 == 2 /* DocsEquationRenderStatus.EmptyEquation */) {
+            if (status_1 == 3 /* DocsEquationRenderStatus.EmptyEquation */) {
                 allEmpty++;
             }
             else {
@@ -175,34 +199,58 @@ function replaceEquations(sizeRaw, delimiter, renderer) {
             if (allEmpty > 10)
                 break; //Assume we quit on 10 consecutive empty equations.
             // quit if all renderers failed or if document failed to load (conflicting authorizations)
-            if (status_1 == 0 /* DocsEquationRenderStatus.AllRenderersFailed */ || status_1 == 3 /* DocsEquationRenderStatus.NoDocument */) {
+            if (status_1 == 0 /* DocsEquationRenderStatus.AllRenderersFailed */ ||
+                status_1 == 1 /* DocsEquationRenderStatus.AuthorizationFailed */ ||
+                status_1 == 5 /* DocsEquationRenderStatus.NoDocument */) {
                 return {
                     lastStatus: status_1,
-                    successCount: c
+                    successCount: c,
+                    autoFixedCount: autoFixedCount,
+                    failureDetails: failureDetails
                 };
             }
-            if (status_1 === 1 /* DocsEquationRenderStatus.ClientRender */ && clientRenderOptions) {
-                console.log("MathJax queued next equation for client rendering.");
-                return {
-                    lastStatus: 1 /* DocsEquationRenderStatus.ClientRender */,
-                    clientEquations: [clientRenderOptions],
-                    successCount: 0
-                };
+            // REASON: Cross-element / cross-paragraph equations we couldn't auto-fix. Record for the
+            // sidebar and skip past so we don't infinite-loop on the same broken equation.
+            if (status_1 === 4 /* DocsEquationRenderStatus.MultiElementEquation */) {
+                if (failureDetail)
+                    failureDetails.push(failureDetail);
+                // failedStartElemIfIsEmpty was set above to nextStartElement (the end delimiter),
+                // so the next findPos call will search after this broken equation.
+                continue;
+            }
+            if (status_1 === 2 /* DocsEquationRenderStatus.ClientRender */ && clientRenderOptions) {
+                // REASON: Collect for batch instead of returning immediately.
+                // This lets Codecogs process all equations it can first, then MathJax handles the rest in parallel.
+                clientRenderBatch.push(clientRenderOptions);
+                continue;
             }
             // could not find next equation
             // move to next section
-            if (status_1 == 5 /* DocsEquationRenderStatus.NoStartDelimiter */ || status_1 == 4 /* DocsEquationRenderStatus.NoEndDelimiter */) {
+            if (status_1 == 7 /* DocsEquationRenderStatus.NoStartDelimiter */ || status_1 == 6 /* DocsEquationRenderStatus.NoEndDelimiter */) {
                 break;
             }
-            if (status_1 != 2 /* DocsEquationRenderStatus.EmptyEquation */) {
+            if (status_1 != 3 /* DocsEquationRenderStatus.EmptyEquation */) {
                 c++;
             }
             console.log("Rendered equations: " + c);
         }
     }
+    // If any equations need client-side MathJax rendering, send them all at once
+    if (clientRenderBatch.length > 0) {
+        console.log("MathJax queued", clientRenderBatch.length, "equations for parallel client rendering.");
+        return {
+            lastStatus: 2 /* DocsEquationRenderStatus.ClientRender */,
+            clientEquations: clientRenderBatch,
+            successCount: c,
+            autoFixedCount: autoFixedCount,
+            failureDetails: failureDetails
+        };
+    }
     return {
-        lastStatus: 6 /* DocsEquationRenderStatus.Success */,
-        successCount: c
+        lastStatus: 8 /* DocsEquationRenderStatus.Success */,
+        successCount: c,
+        autoFixedCount: autoFixedCount,
+        failureDetails: failureDetails
     };
 }
 function hasEscapedSingleDollar(text, offset) {
@@ -257,6 +305,100 @@ function findNextDelimiter(docBody, renderOptions, fromRange) {
                 isEmpty:
                     1 if eqn is "" and 0 if not. Assume we close on 4 consecutive empty ones.
 */
+// REASON: Walk up the parent chain to find the containing top-level body child (Paragraph or
+// ListItem) for a Text element. We need this to detect equations that cross paragraph boundaries
+// (the Enter-instead-of-Shift+Enter case) so we can auto-fix them.
+function getContainingTopLevelChild(element, body) {
+    var current = element;
+    while (current != null) {
+        var parent_1 = current.getParent();
+        if (parent_1 == null) {
+            return null;
+        }
+        var parentType = parent_1.getType();
+        if (parentType === DocumentApp.ElementType.BODY_SECTION ||
+            parentType === DocumentApp.ElementType.HEADER_SECTION ||
+            parentType === DocumentApp.ElementType.FOOTER_SECTION) {
+            try {
+                // ContainerElement already exposes getChildIndex, so no cast needed.
+                var idx = parent_1.getChildIndex(current);
+                return { topLevelChild: current, indexInBody: idx };
+            }
+            catch (err) {
+                // Stale or detached element
+                return null;
+            }
+        }
+        current = parent_1;
+    }
+    return null;
+}
+// REASON: When findText returns delimiters in different paragraphs, the user almost always
+// pressed Enter instead of Shift+Enter inside a multiline equation. We auto-fix by merging
+// every paragraph from start to end into the start paragraph, joining them with `\r` (the
+// in-paragraph soft line break character that Docs uses for Shift+Enter). The original
+// rendering loop then re-runs findPos and the equation now lives in a single Text element.
+//
+// What breaks if removed: every multiline equation entered with Enter raises a "End index N
+// must be >= start index M" exception in findPos and the user gets a useless generic error.
+//
+// Limitations: any rich formatting (bold/italic/font/color) on text inside the merged
+// paragraphs is collapsed because appendText only takes a string. We accept that loss because
+// the merged region is the equation itself, which gets replaced by an image anyway.
+function tryAutoMergeMultiParagraphEquation(body, startParaIdx, endParaIdx) {
+    if (endParaIdx <= startParaIdx) {
+        return { success: false, reason: "Paragraph indices out of order" };
+    }
+    // Verify every paragraph in the span is a plain Paragraph containing only Text children.
+    // If there are tables, inline images, drawings, etc., merging would either fail outright or
+    // silently destroy user content - safer to bail and show a precise error.
+    for (var i = startParaIdx; i <= endParaIdx; i++) {
+        var child = body.getChild(i);
+        var childType = child.getType();
+        if (childType !== DocumentApp.ElementType.PARAGRAPH) {
+            return { success: false, reason: "Cross-paragraph equation includes a " + childType + " block" };
+        }
+        var para = child.asParagraph();
+        for (var j = 0; j < para.getNumChildren(); j++) {
+            var innerType = para.getChild(j).getType();
+            if (innerType !== DocumentApp.ElementType.TEXT) {
+                return { success: false, reason: "Cross-paragraph equation contains a non-text element (" + innerType + ")" };
+            }
+        }
+    }
+    var startPara = body.getChild(startParaIdx).asParagraph();
+    var numToMerge = endParaIdx - startParaIdx;
+    // REASON: Forward loop, always grabbing the paragraph immediately after startPara.
+    // After each removeFromParent the indices above startParaIdx all shift down by one, so
+    // (startParaIdx + 1) consistently points at the next paragraph to merge.
+    for (var i = 0; i < numToMerge; i++) {
+        var nextPara = body.getChild(startParaIdx + 1).asParagraph();
+        var text = nextPara.getText();
+        // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
+        // See newlineCharacter comment near top of this file.
+        startPara.appendText("\r" + text);
+        nextPara.removeFromParent();
+    }
+    return { success: true, reason: "Merged " + numToMerge + " paragraph(s) with line breaks" };
+}
+// REASON: Build a short snippet of the equation start that the user can ctrl-F for in their
+// document. We grab from the start delimiter forward, capping at 80 chars and stopping at the
+// first paragraph break so the snippet stays on one line in the sidebar.
+function buildEquationSnippet(startElement) {
+    try {
+        var text = startElement.getElement().asText().getText();
+        var startOffset = startElement.getStartOffset();
+        if (startOffset < 0 || startOffset >= text.length) {
+            return "";
+        }
+        var tail = text.substring(startOffset, Math.min(text.length, startOffset + 80));
+        // Strip line break characters so it renders cleanly in the sidebar
+        return tail.replace(/[\r\n]/g, " ").trim();
+    }
+    catch (err) {
+        return "";
+    }
+}
 function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     if (prevFailedStartElemIfIsEmpty === void 0) { prevFailedStartElemIfIsEmpty = null; }
     Common.debugLog("Checking document section index # ", index);
@@ -264,13 +406,13 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     var docBody = getBodyFromIndex(index);
     if (docBody == null) {
         return {
-            status: 3 /* DocsEquationRenderStatus.NoDocument */
+            status: 5 /* DocsEquationRenderStatus.NoDocument */
         };
     }
     var startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty);
     if (startElement == null) {
         return {
-            status: 5 /* DocsEquationRenderStatus.NoStartDelimiter */
+            status: 7 /* DocsEquationRenderStatus.NoStartDelimiter */
         };
     }
     var placeHolderStart = startElement.getStartOffset(); //position of image insertion
@@ -278,7 +420,7 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     // could not find the ending delimiter after the start
     if (endElement == null) {
         return {
-            status: 4 /* DocsEquationRenderStatus.NoEndDelimiter */
+            status: 6 /* DocsEquationRenderStatus.NoEndDelimiter */
         };
     }
     var placeHolderEnd = endElement.getEndOffsetInclusive(); //text between placeHolderStart and placeHolderEnd will be permanently deleted
@@ -290,14 +432,93 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
         return {
             // start from the end element next time to avoid an infinite loop
             nextStartElement: endElement,
-            status: 2 /* DocsEquationRenderStatus.EmptyEquation */
+            status: 3 /* DocsEquationRenderStatus.EmptyEquation */
         };
     }
-    // build the RangeElement for this equation
-    // we make the assumption that the entire equation is contained within one TextElement
-    var range = DocsApp.getActive().newRange()
-        .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
-        .build();
+    // REASON: The legacy assumption was "start and end delimiters live in the same Text element."
+    // That breaks in two real-world cases:
+    //   1. Multi-paragraph equations: user pressed Enter (paragraph break) inside the equation
+    //      instead of Shift+Enter. start and end live in different paragraphs entirely.
+    //   2. Multi-element equations: even within a single paragraph, an inline image or formatting
+    //      change between the delimiters can split the paragraph into multiple Text children.
+    //
+    // Both cases used to throw an uncaught "End index (N) must be >= start index (M)" exception
+    // from addElement, which bubbled up to the sidebar as a generic error.
+    //
+    // Now we detect both cases preemptively, auto-fix case 1 by merging the paragraphs, and
+    // return a precise MultiElementEquation status with a snippet+hint for case 2.
+    var startContainer = getContainingTopLevelChild(startElement.getElement(), docBody);
+    var endContainer = getContainingTopLevelChild(endElement.getElement(), docBody);
+    if (startContainer && endContainer && startContainer.indexInBody !== endContainer.indexInBody) {
+        // Cross-paragraph case (1). Try to auto-merge.
+        var snippet = buildEquationSnippet(startElement);
+        console.log("Detected multi-paragraph equation:", JSON.stringify({
+            startParaIdx: startContainer.indexInBody,
+            endParaIdx: endContainer.indexInBody,
+            snippet: snippet
+        }));
+        var merge = tryAutoMergeMultiParagraphEquation(docBody, startContainer.indexInBody, endContainer.indexInBody);
+        if (merge.success) {
+            console.log("Auto-fixed multi-paragraph equation:", merge.reason);
+            // REASON: Signal an auto-fix to the caller via equationSize === -1 so the loop
+            // increments autoFixedCount and re-runs findPos against the fresh document state.
+            // We can't recurse here because the caller's `failedStartElemIfIsEmpty` would be stale.
+            return {
+                status: 8 /* DocsEquationRenderStatus.Success */,
+                equationSize: -1
+            };
+        }
+        return {
+            status: 4 /* DocsEquationRenderStatus.MultiElementEquation */,
+            // Skip past the broken end delimiter so we don't loop on it forever
+            nextStartElement: endElement,
+            failureDetail: {
+                reason: "multi-paragraph",
+                snippet: snippet || "(unknown)",
+                hint: "This equation appears to span multiple paragraphs. Inside an equation, use Shift+Enter (line break) instead of Enter (paragraph break). " + merge.reason + "."
+            }
+        };
+    }
+    // Same top-level container but possibly different Text children (e.g., split by inline
+    // image or formatting boundary). Detect by trying the addElement build under a try/catch
+    // so we don't have to fragile-compare element references.
+    // REASON: We deliberately wrap *only* the range build in try/catch, not the downstream
+    // findEquationAndPlaceImage call. Catching findEquationAndPlaceImage failures here would
+    // hide unrelated bugs (network/render failures) behind a generic "multi-element" message.
+    var range;
+    try {
+        range = DocsApp.getActive().newRange()
+            .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
+            .build();
+    }
+    catch (rangeErr) {
+        var snippet = buildEquationSnippet(startElement);
+        console.warn("Could not build equation range:", JSON.stringify({
+            error: String(rangeErr),
+            startOffset: startElement.getStartOffset(),
+            endOffset: endElement.getEndOffsetInclusive(),
+            snippet: snippet
+        }));
+        // REASON: Distinguish "stale offsets after a prior mutation" from "real cross-element"
+        // by inspecting the error message. Stale-offset errors look like "Index (N) must be less
+        // than the content length (M)" — these happen when an earlier render moved text under us
+        // and the user can usually fix them just by re-running the renderer. Cross-element errors
+        // look like "End index (N) must be greater or equal to start index (M)" — these need a
+        // structural fix in the doc.
+        var errMsg = String(rangeErr || "");
+        var isStaleOffset = /Index \([0-9]+\) must be less than/.test(errMsg) || /less than the content length/.test(errMsg);
+        return {
+            status: 4 /* DocsEquationRenderStatus.MultiElementEquation */,
+            nextStartElement: endElement,
+            failureDetail: {
+                reason: isStaleOffset ? "stale-offset" : "multi-element",
+                snippet: snippet || "(unknown)",
+                hint: isStaleOffset
+                    ? "This equation could not be located after a prior render. Try clicking 'Render Equations' again — it usually works on the second try."
+                    : "This equation appears to cross a formatting boundary or an inline element. Try removing any formatting changes (bold, italic, font, color) inside the $$ delimiters, or remove inline images from the equation."
+            }
+        };
+    }
     return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
 }
 function getEquation(rangeElement, delimiters) {
@@ -365,7 +586,7 @@ function clientRenderComplete(equations) {
             }
             var equationBlob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
             var result = placeImage(rangeElements[0], equationBlob, mathjaxRenderer, equation.options.equationLinkEncoded, equation.options.size, equation.options.delim);
-            if (result.status === 6 /* DocsEquationRenderStatus.Success */) {
+            if (result.status === 8 /* DocsEquationRenderStatus.Success */) {
                 c++;
             }
         }
@@ -377,7 +598,7 @@ function clientRenderComplete(equations) {
         }
     }
     return {
-        lastStatus: 6 /* DocsEquationRenderStatus.Success */,
+        lastStatus: 8 /* DocsEquationRenderStatus.Success */,
         successCount: c
     };
     // clean up - remove all of our ranges
@@ -404,7 +625,7 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     if (equationOriginal == "") {
         console.log("No equation but undetected start and end as ", startElement.getStartOffset(), " ", startElement.getEndOffsetInclusive());
         return {
-            status: 2 /* DocsEquationRenderStatus.EmptyEquation */,
+            status: 3 /* DocsEquationRenderStatus.EmptyEquation */,
             // TODO: this _should_ be impossible - empty equations should be detected in findPos()
             nextStartElement: startElement
         };
@@ -415,29 +636,28 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     var _a = getRgbFromHex(colorHex), r = _a[0], g = _a[1], b = _a[2];
     // add color info to render options
     var coloredRenderOptions = __assign(__assign({}, renderOptions), { r: r, g: g, b: b });
-    // send info to the client for rendering
+    // send info to the client for rendering (explicit MathJax mode)
     if (renderOptions.clientRender) {
-        // we don't need URL encoding or double escaping for client renderers
-        var clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
-        var doc = DocumentApp.getActiveDocument();
-        var range = doc.newRange()
-            .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
-            .build();
-        // save this range for later
-        var namedRange = doc.addNamedRange("ale-equation-range", range);
-        var clientRenderOptions = __assign(__assign({}, coloredRenderOptions), { size: size, rangeId: namedRange.getId(), equation: clientEquation, equationLinkEncoded: encodeURIComponent(clientEquation) });
-        // make sure we can retrieve this element later
-        return {
-            status: 1 /* DocsEquationRenderStatus.ClientRender */,
-            equationSize: size,
-            clientRenderOptions: clientRenderOptions,
-            nextStartElement: startElement
-        };
+        return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
     }
-    var _b = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions), resp = _b.resp, renderer = _b.renderer, worked = _b.worked;
+    // REASON: In auto mode, try Codecogs first. If Codecogs fails, fall back to MathJax on the client.
+    // If MathJax also fails, the client calls clientRenderFailed to try Texrendr/Sciweavers.
+    if (renderOptions.autoFallbackToClient) {
+        var codecogsResult = renderEquationWithCompatibility(equationOriginal, __assign(__assign({}, coloredRenderOptions), { allowedServerFamilies: ["Codecogs"] }));
+        if (codecogsResult.worked <= Common.capableRenderers && codecogsResult.resp && codecogsResult.renderer) {
+            // Codecogs succeeded
+            if (escape(codecogsResult.resp.getBlob().getDataAsString()).substring(0, 50) == Common.invalidEquationHashCodecogsFirst50) {
+                codecogsResult.renderer = Common.getRenderer(Common.rendererIds.CODECOGS);
+            }
+            return placeImage(startElement, codecogsResult.resp.getBlob(), codecogsResult.renderer, equationOriginal, size, renderOptions.delim);
+        }
+        // Codecogs failed - fall back to MathJax on client
+        return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
+    }
+    var _b = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions), resp = _b.resp, renderer = _b.renderer, worked = _b.worked, authorizationError = _b.authorizationError;
     if (worked > Common.capableRenderers || !resp || !renderer)
         return {
-            status: 0 /* DocsEquationRenderStatus.AllRenderersFailed */
+            status: authorizationError ? 1 /* DocsEquationRenderStatus.AuthorizationFailed */ : 0 /* DocsEquationRenderStatus.AllRenderersFailed */
         };
     // SAVING FORMATTING
     Common.reportDeltaTime(511);
@@ -446,6 +666,89 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     }
     Common.reportDeltaTime(517);
     return placeImage(startElement, resp.getBlob(), renderer, equationOriginal, size, renderOptions.delim);
+}
+function buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size) {
+    // we don't need URL encoding or double escaping for client renderers
+    var clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
+    var doc = DocumentApp.getActiveDocument();
+    var range = doc.newRange()
+        .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
+        .build();
+    // save this range for later
+    var namedRange = doc.addNamedRange("ale-equation-range", range);
+    var clientRenderOptions = __assign(__assign({}, coloredRenderOptions), { size: size, rangeId: namedRange.getId(), equation: clientEquation, equationLinkEncoded: encodeURIComponent(clientEquation) });
+    return {
+        status: 2 /* DocsEquationRenderStatus.ClientRender */,
+        equationSize: size,
+        clientRenderOptions: clientRenderOptions,
+        nextStartElement: startElement
+    };
+}
+/**
+ * Called by the client when MathJax rendering fails in auto mode.
+ * Tries remaining server-side renderers (Texrendr, Sciweavers) for the failed equations.
+ * @public
+ */
+function clientRenderFailed(equations) {
+    var c = 0;
+    var authorizationFailure = false;
+    console.log("MathJax client render failed, trying server fallback for", equations.length, "equations");
+    // Go backwards so that the named ranges for multiple equations in the same paragraph don't get removed
+    equations.reverse();
+    for (var _i = 0, equations_2 = equations; _i < equations_2.length; _i++) {
+        var equation = equations_2[_i];
+        var namedRange = null;
+        try {
+            namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+            if (!namedRange) {
+                console.warn("Server fallback: range disappeared:", equation.options.rangeId);
+                continue;
+            }
+            var rangeElements = namedRange.getRange().getRangeElements();
+            if (rangeElements.length === 0) {
+                console.warn("Server fallback: range is empty:", equation.options.rangeId);
+                continue;
+            }
+            var equationOriginal = Common.reEncode(equation.options.equation, DocsApp);
+            // REASON: Try Texrendr and Sciweavers only - Codecogs already failed, MathJax already failed.
+            var fallbackResult = renderEquationWithCompatibility(equationOriginal, {
+                size: equation.options.size,
+                defaultSize: equation.options.size,
+                inline: equation.options.inline,
+                delim: equation.options.delim,
+                clientRender: false,
+                r: equation.options.r,
+                g: equation.options.g,
+                b: equation.options.b,
+                allowedServerFamilies: ["Texrendr", "Sciweavers", "Sciweavers_old", "Roger's renderer", "Number empire"]
+            });
+            if (fallbackResult.worked > Common.capableRenderers || !fallbackResult.resp || !fallbackResult.renderer) {
+                if (fallbackResult.authorizationError) {
+                    authorizationFailure = true;
+                }
+                continue;
+            }
+            var equationBlob = fallbackResult.resp.getBlob();
+            var result = placeImage(rangeElements[0], equationBlob, fallbackResult.renderer, equationOriginal, equation.options.size, equation.options.delim);
+            if (result.status === 8 /* DocsEquationRenderStatus.Success */) {
+                c++;
+            }
+        }
+        catch (error) {
+            console.error("Server fallback render failed.", error);
+        }
+        finally {
+            namedRange === null || namedRange === void 0 ? void 0 : namedRange.remove();
+        }
+    }
+    return {
+        lastStatus: c > 0
+            ? 8 /* DocsEquationRenderStatus.Success */
+            : authorizationFailure
+                ? 1 /* DocsEquationRenderStatus.AuthorizationFailed */
+                : 0 /* DocsEquationRenderStatus.AllRenderersFailed */,
+        successCount: c
+    };
 }
 function placeImage(startElement, renderedEquation, renderer, equation, size, delim) {
     // GET VARIABLES
@@ -533,7 +836,7 @@ function repairImage(paragraph, childIndex, size, renderer, delim, textCopy, res
     Common.reportDeltaTime(595);
     Common.sizeImage(DocsApp, paragraph, childIndex + 1, Math.round(height * multiple), Math.round(width * multiple));
     return {
-        status: 6 /* DocsEquationRenderStatus.Success */,
+        status: 8 /* DocsEquationRenderStatus.Success */,
         equationSize: oldSize
     };
 }
@@ -579,8 +882,8 @@ function removeAll(defaultDelimRaw) {
                 image.removeFromParent();
                 continue;
             }
-            var parent_1 = image.getParent();
-            parent_1.insertText(imageIndex, delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+            var parent_2 = image.getParent();
+            parent_2.insertText(imageIndex, delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
             image.removeFromParent();
             counter += 1;
         }
@@ -599,43 +902,54 @@ function editEquations(sizeRaw, delimiter, renderer) {
     var defaultDelim = Common.getDelimiters(delimiter);
     Common.savePrefs(sizeRaw, delimiter, renderer);
     var cursor = DocumentApp.getActiveDocument().getCursor();
-    if (cursor) {
-        // Attempt to insert text at the cursor position. If the insertion returns null, the cursor's
-        // containing element doesn't allow insertions, so show the user an error message.
-        var element = cursor.getElement(); //startElement
-        if (element) {
-            console.log("Valid cursor.");
-            var position = cursor.getOffset(); //offset
-            if (position >= element.getNumChildren()) {
-                return 0 /* Common.DerenderResult.CursorNotFound */;
-            }
-            //element.getChild(position).removeFromParent();  //SUCCESSFULLY REMOVES IMAGE FROM PARAGRAPH
-            // console.log(element.getAllContent(), element.type())
-            var image = element.getChild(position).asInlineImage();
-            Common.debugLog("Image height", image.getHeight());
-            var origURL = image.getLinkUrl();
-            if (!origURL) {
-                return 4 /* Common.DerenderResult.NullUrl */;
-            }
-            Common.debugLog("Original URL from image", origURL);
-            var result = Common.derenderEquation(origURL, DocsApp);
-            if (!result)
-                return 2 /* Common.DerenderResult.InvalidUrl */;
-            var newDelim = result.delim, origEq = result.origEq;
-            var delim = newDelim || defaultDelim;
-            if (origEq.length <= 0) {
-                console.log("Empty equation derender.");
-                return 1 /* Common.DerenderResult.EmptyEquation */;
-            }
-            cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
-            element.getChild(position + 1).removeFromParent();
-            return 5 /* Common.DerenderResult.Success */;
-        }
-        else {
-            return 3 /* Common.DerenderResult.NonExistentElement */;
-        }
-    }
-    else {
+    if (!cursor) {
         return 0 /* Common.DerenderResult.CursorNotFound */;
     }
+    var elementRaw = cursor.getElement();
+    if (!elementRaw) {
+        return 3 /* Common.DerenderResult.NonExistentElement */;
+    }
+    // REASON: Cursor.getElement() can return any Element subtype (Table, TableOfContents,
+    // FootnoteSection, etc.) - not just Paragraph/ListItem. The previous code did an unchecked
+    // `as ListItem | Paragraph` cast and then called .getNumChildren(), which crashed with
+    // "TypeError: element.getNumChildren is not a function" for users whose cursor was inside
+    // a table cell or footnote. Validate the element type up front.
+    var elementType = elementRaw.getType();
+    if (elementType !== DocumentApp.ElementType.PARAGRAPH && elementType !== DocumentApp.ElementType.LIST_ITEM) {
+        console.log("editEquations: cursor is in unsupported element type", elementType);
+        return 3 /* Common.DerenderResult.NonExistentElement */;
+    }
+    var element = elementRaw;
+    console.log("Valid cursor.");
+    var position = cursor.getOffset(); //offset
+    if (position >= element.getNumChildren()) {
+        return 0 /* Common.DerenderResult.CursorNotFound */;
+    }
+    // REASON: getChild(position).asInlineImage() throws "TEXT can't be cast to INLINE_IMAGE"
+    // when the user's cursor is on text instead of an equation image. Check the child type
+    // first and return a precise status so the sidebar can tell them to click the image.
+    var childAtCursor = element.getChild(position);
+    if (childAtCursor.getType() !== DocumentApp.ElementType.INLINE_IMAGE) {
+        console.log("editEquations: child at cursor is not an inline image", childAtCursor.getType());
+        return 3 /* Common.DerenderResult.NonExistentElement */;
+    }
+    var image = childAtCursor.asInlineImage();
+    Common.debugLog("Image height", image.getHeight());
+    var origURL = image.getLinkUrl();
+    if (!origURL) {
+        return 4 /* Common.DerenderResult.NullUrl */;
+    }
+    Common.debugLog("Original URL from image", origURL);
+    var result = Common.derenderEquation(origURL, DocsApp);
+    if (!result)
+        return 2 /* Common.DerenderResult.InvalidUrl */;
+    var newDelim = result.delim, origEq = result.origEq;
+    var delim = newDelim || defaultDelim;
+    if (origEq.length <= 0) {
+        console.log("Empty equation derender.");
+        return 1 /* Common.DerenderResult.EmptyEquation */;
+    }
+    cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+    element.getChild(position + 1).removeFromParent();
+    return 5 /* Common.DerenderResult.Success */;
 }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -15,26 +15,28 @@ var __assign = (this && this.__assign) || function () {
 };
 /* exported onOpen, showSidebar, replaceEquations */
 var DEBUG = false; //doing ctrl + m to get key to see errors is still needed; DEBUG is for all nondiagnostic information
-var DocsApp = {
-    getUi: function () {
-        var activeUi = DocumentApp.getUi();
-        return activeUi;
-    },
-    getBody: function () {
-        var activeBody = DocumentApp.getActiveDocument().getBody();
-        return activeBody;
-    },
-    getActive: function () {
-        var activeDoc = DocumentApp.getActiveDocument();
-        return activeDoc;
-    },
-    getPageWidth: function () {
-        var activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
-        return activeWidth;
-    },
-    // A \n in Docs represents a paragraph break, while a \r (\x0D) represents a break within a paragraph
-    newlineCharacter: "%0D"
-};
+function getDocsApp() {
+    return {
+        getUi: function () {
+            var activeUi = DocumentApp.getUi();
+            return activeUi;
+        },
+        getBody: function () {
+            var activeBody = DocumentApp.getActiveDocument().getBody();
+            return activeBody;
+        },
+        getActive: function () {
+            var activeDoc = DocumentApp.getActiveDocument();
+            return activeDoc;
+        },
+        getPageWidth: function () {
+            var activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
+            return activeWidth;
+        },
+        // A \n in Docs represents a paragraph break, while a \r (\x0D) represents a break within a paragraph
+        newlineCharacter: "%0D"
+    };
+}
 /** //8.03 - De-Render, Inline, Advanced Delimiters > Fixed Inline Not Appearing
  * Creates a menu entry in the Google Docs UI when the document is opened.
  *
@@ -44,7 +46,7 @@ var DocsApp = {
  */
 function onOpen(_e) {
     try {
-        DocsApp.getUi().createAddonMenu().addItem("Start", "showSidebar").addToUi();
+        DocumentApp.getUi().createAddonMenu().addItem("Start", "showSidebar").addToUi();
     }
     catch (error) {
         // Manual runs from the Apps Script editor do not have a document UI context.
@@ -71,7 +73,7 @@ function showSidebar() {
         .setTitle("Auto-LaTeX Equations")
         .setSandboxMode(HtmlService.SandboxMode.IFRAME) // choose mode IFRAME which is fastest option
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL); // allow third party Docs clients
-    DocsApp.getUi().showSidebar(ui);
+    DocumentApp.getUi().showSidebar(ui);
 }
 /**
  * @public
@@ -493,7 +495,7 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     // hide unrelated bugs (network/render failures) behind a generic "multi-element" message.
     var range;
     try {
-        range = DocsApp.getActive().newRange()
+        range = getDocsApp().getActive().newRange()
             .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
             .build();
     }
@@ -535,7 +537,7 @@ function getEquation(rangeElement, delimiters) {
         .getText()
         .substring(rangeElement.getStartOffset() + delimiters[4], rangeElement.getEndOffsetInclusive() - delimiters[4] + 1);
     Common.debugLog("See equation", equation);
-    var equationStringEncoded = Common.reEncode(equation, DocsApp); //escape deprecated
+    var equationStringEncoded = Common.reEncode(equation, getDocsApp()); //escape deprecated
     Common.reportDeltaTime(290);
     //console.log("Encoded: " + equationStringEncoded);
     return equationStringEncoded;
@@ -580,7 +582,7 @@ function clientRenderComplete(equations) {
         var equation = equations_1[_i];
         var namedRange = null;
         try {
-            namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+            namedRange = getDocsApp().getActive().getNamedRangeById(equation.options.rangeId);
             if (!namedRange) {
                 console.warn("MathJax client render range disappeared before completion:", equation.options.rangeId);
                 continue;
@@ -705,7 +707,7 @@ function clientRenderFailed(equations) {
         var equation = equations_2[_i];
         var namedRange = null;
         try {
-            namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+            namedRange = getDocsApp().getActive().getNamedRangeById(equation.options.rangeId);
             if (!namedRange) {
                 console.warn("Server fallback: range disappeared:", equation.options.rangeId);
                 continue;
@@ -715,7 +717,7 @@ function clientRenderFailed(equations) {
                 console.warn("Server fallback: range is empty:", equation.options.rangeId);
                 continue;
             }
-            var equationOriginal = Common.reEncode(equation.options.equation, DocsApp);
+            var equationOriginal = Common.reEncode(equation.options.equation, getDocsApp());
             // REASON: Try Texrendr and Sciweavers only - Codecogs already failed, MathJax already failed.
             var fallbackResult = renderEquationWithCompatibility(equationOriginal, {
                 size: equation.options.size,
@@ -840,14 +842,14 @@ function repairImage(paragraph, childIndex, size, renderer, delim, textCopy, res
         // TODO: When MathJax supports changing font, switch to a font that's more similar to CodeCogs
         multiple = 1.26 / 5;
     Common.reportDeltaTime(595);
-    Common.sizeImage(DocsApp, paragraph, childIndex + 1, Math.round(height * multiple), Math.round(width * multiple));
+    Common.sizeImage(getDocsApp(), paragraph, childIndex + 1, Math.round(height * multiple), Math.round(width * multiple));
     return {
         status: 8 /* DocsEquationRenderStatus.Success */,
         equationSize: oldSize
     };
 }
 function getBodyFromIndex(index) {
-    var doc = DocsApp.getActive();
+    var doc = getDocsApp().getActive();
     var p = doc.getBody().getParent();
     var all = p.getNumChildren();
     Common.assert(index < all, "index < all");
@@ -866,7 +868,7 @@ function getBodyFromIndex(index) {
 function removeAll(defaultDelimRaw) {
     var counter = 0;
     var defaultDelim = Common.getDelimiters(defaultDelimRaw);
-    for (var index = 0; index < DocsApp.getBody().getParent().getNumChildren(); index++) {
+    for (var index = 0; index < getDocsApp().getBody().getParent().getNumChildren(); index++) {
         var body = getBodyFromIndex(index);
         var img = body === null || body === void 0 ? void 0 : body.getImages(); //places all InlineImages from the active document into the array img
         for (var i = 0; i < ((img === null || img === void 0 ? void 0 : img.length) || 0); i++) {
@@ -877,7 +879,7 @@ function removeAll(defaultDelimRaw) {
             }
             // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
             // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-            var result = Common.derenderEquation(origURL, DocsApp);
+            var result = Common.derenderEquation(origURL, getDocsApp());
             if (!result)
                 continue;
             var origEq = result.origEq, newDelim = result.delim;
@@ -946,7 +948,7 @@ function editEquations(sizeRaw, delimiter, renderer) {
         return 4 /* Common.DerenderResult.NullUrl */;
     }
     Common.debugLog("Original URL from image", origURL);
-    var result = Common.derenderEquation(origURL, DocsApp);
+    var result = Common.derenderEquation(origURL, getDocsApp());
     if (!result)
         return 2 /* Common.DerenderResult.InvalidUrl */;
     var newDelim = result.delim, origEq = result.origEq;

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -152,6 +152,8 @@ function renderEquationWithCompatibility(equationOriginal: string, renderOptions
 function replaceEquations(sizeRaw: string, delimiter: string, renderer: string = "auto") {
   const quality = 900;
   const clientRender = renderer === "mathjax";
+  // REASON: In auto mode, try Codecogs server-side first, then MathJax on client, then Texrendr/Sciweavers.
+  const autoFallbackToClient = renderer === "auto";
   if (clientRender) {
     console.log("MathJax render requested.", JSON.stringify({ sizeRaw, delimiter }));
   }
@@ -186,13 +188,19 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     delim,
     
     clientRender,
-    
+    autoFallbackToClient,
+
     // TODO: color support for Docs
     r: 0,
     g: 0,
     b: 0
   };
   
+  // REASON: Collect equations that need client-side MathJax rendering instead of returning
+  // on the first one. This allows Codecogs to batch-process all equations it can handle,
+  // then send ALL remaining failures to the client for parallel MathJax rendering.
+  const clientRenderBatch: AutoLatexCommon.ClientRenderOptions[] = [];
+
   const childCount = body.getBody().getParent().getNumChildren();
   Common.reportDeltaTime(156);
   for (let index = 0; index < childCount; index++) {
@@ -209,16 +217,16 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
       if (nextStartElement) failedStartElemIfIsEmpty = nextStartElement;
       // if we found an actual equation, update the default size
       if (equationSize) baseRenderOptions.defaultSize = equationSize;
-        
+
       // count consecutive empty equations
       if (status == DocsEquationRenderStatus.EmptyEquation) {
         allEmpty++;
       } else {
         allEmpty = 0;
       }
-      
+
       if (allEmpty > 10) break; //Assume we quit on 10 consecutive empty equations.
-      
+
       // quit if all renderers failed or if document failed to load (conflicting authorizations)
       if (status == DocsEquationRenderStatus.AllRenderersFailed || status == DocsEquationRenderStatus.NoDocument) {
         return {
@@ -226,29 +234,37 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
           successCount: c
         };
       }
-      
+
       if (status === DocsEquationRenderStatus.ClientRender && clientRenderOptions) {
-        console.log("MathJax queued next equation for client rendering.");
-        return {
-          lastStatus: DocsEquationRenderStatus.ClientRender,
-          clientEquations: [clientRenderOptions],
-          successCount: 0
-        };
+        // REASON: Collect for batch instead of returning immediately.
+        // This lets Codecogs process all equations it can first, then MathJax handles the rest in parallel.
+        clientRenderBatch.push(clientRenderOptions);
+        continue;
       }
-      
+
       // could not find next equation
       // move to next section
       if (status == DocsEquationRenderStatus.NoStartDelimiter || status == DocsEquationRenderStatus.NoEndDelimiter) {
         break;
       }
-      
+
       if (status != DocsEquationRenderStatus.EmptyEquation) {
         c++;
       }
       console.log("Rendered equations: " + c);
     }
   }
-  
+
+  // If any equations need client-side MathJax rendering, send them all at once
+  if (clientRenderBatch.length > 0) {
+    console.log("MathJax queued", clientRenderBatch.length, "equations for parallel client rendering.");
+    return {
+      lastStatus: DocsEquationRenderStatus.ClientRender,
+      clientEquations: clientRenderBatch,
+      successCount: c
+    };
+  }
+
   return {
     lastStatus: DocsEquationRenderStatus.Success,
     successCount: c
@@ -503,32 +519,31 @@ function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.Range
     r, g, b,
   };
   
-  // send info to the client for rendering
+  // send info to the client for rendering (explicit MathJax mode)
   if (renderOptions.clientRender) {
-    // we don't need URL encoding or double escaping for client renderers
-    const clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
-    const doc = DocumentApp.getActiveDocument();
-    const range = doc.newRange()
-      .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
-      .build();
-    // save this range for later
-    const namedRange = doc.addNamedRange("ale-equation-range", range);
-    const clientRenderOptions: AutoLatexCommon.ClientRenderOptions = {
-      ...coloredRenderOptions,
-      size,
-      rangeId: namedRange.getId(),
-      equation: clientEquation,
-      equationLinkEncoded: encodeURIComponent(clientEquation)
-    };
-    // make sure we can retrieve this element later
-    return {
-      status: DocsEquationRenderStatus.ClientRender,
-      equationSize: size,
-      clientRenderOptions,
-      nextStartElement: startElement
-    };
+    return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
   }
-  
+
+  // REASON: In auto mode, try Codecogs first. If Codecogs fails, fall back to MathJax on the client.
+  // If MathJax also fails, the client calls clientRenderFailed to try Texrendr/Sciweavers.
+  if (renderOptions.autoFallbackToClient) {
+    const codecogsResult = renderEquationWithCompatibility(equationOriginal, {
+      ...coloredRenderOptions,
+      allowedServerFamilies: ["Codecogs"]
+    });
+
+    if (codecogsResult.worked <= Common.capableRenderers && codecogsResult.resp && codecogsResult.renderer) {
+      // Codecogs succeeded
+      if (escape(codecogsResult.resp.getBlob().getDataAsString()).substring(0, 50) == Common.invalidEquationHashCodecogsFirst50) {
+        codecogsResult.renderer = Common.getRenderer(Common.rendererIds.CODECOGS);
+      }
+      return placeImage(startElement, codecogsResult.resp.getBlob(), codecogsResult.renderer, equationOriginal, size, renderOptions.delim);
+    }
+
+    // Codecogs failed - fall back to MathJax on client
+    return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
+  }
+
   let { resp, renderer, worked } = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions);
   if (worked > Common.capableRenderers || !resp || !renderer) return {
     status: DocsEquationRenderStatus.AllRenderersFailed
@@ -543,6 +558,101 @@ function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.Range
   return placeImage(startElement, resp.getBlob(), renderer, equationOriginal, size, renderOptions.delim);
 }
   
+function buildClientRenderResponse(
+  textElement: GoogleAppsScript.Document.Text,
+  startElement: GoogleAppsScript.Document.RangeElement,
+  equationOriginal: string,
+  coloredRenderOptions: AutoLatexCommon.RenderOptions & { r: number; g: number; b: number },
+  size: number
+): DocsEquationRenderResult {
+  // we don't need URL encoding or double escaping for client renderers
+  const clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
+  const doc = DocumentApp.getActiveDocument();
+  const range = doc.newRange()
+    .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
+    .build();
+  // save this range for later
+  const namedRange = doc.addNamedRange("ale-equation-range", range);
+  const clientRenderOptions: AutoLatexCommon.ClientRenderOptions = {
+    ...coloredRenderOptions,
+    size,
+    rangeId: namedRange.getId(),
+    equation: clientEquation,
+    equationLinkEncoded: encodeURIComponent(clientEquation)
+  };
+  return {
+    status: DocsEquationRenderStatus.ClientRender,
+    equationSize: size,
+    clientRenderOptions,
+    nextStartElement: startElement
+  };
+}
+
+/**
+ * Called by the client when MathJax rendering fails in auto mode.
+ * Tries remaining server-side renderers (Texrendr, Sciweavers) for the failed equations.
+ * @public
+ */
+function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOptions }[]) {
+  let c = 0;
+  console.log("MathJax client render failed, trying server fallback for", equations.length, "equations");
+
+  // Go backwards so that the named ranges for multiple equations in the same paragraph don't get removed
+  equations.reverse();
+
+  for (const equation of equations) {
+    let namedRange: GoogleAppsScript.Document.NamedRange | null = null;
+    try {
+      namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+      if (!namedRange) {
+        console.warn("Server fallback: range disappeared:", equation.options.rangeId);
+        continue;
+      }
+
+      const rangeElements = namedRange.getRange().getRangeElements();
+      if (rangeElements.length === 0) {
+        console.warn("Server fallback: range is empty:", equation.options.rangeId);
+        continue;
+      }
+
+      const equationOriginal = Common.reEncode(equation.options.equation, DocsApp);
+
+      // REASON: Try Texrendr and Sciweavers only - Codecogs already failed, MathJax already failed.
+      const fallbackResult = renderEquationWithCompatibility(equationOriginal, {
+        size: equation.options.size,
+        defaultSize: equation.options.size,
+        inline: equation.options.inline,
+        delim: equation.options.delim,
+        clientRender: false,
+        r: equation.options.r,
+        g: equation.options.g,
+        b: equation.options.b,
+        allowedServerFamilies: ["Texrendr", "Sciweavers", "Sciweavers_old", "Roger's renderer", "Number empire"]
+      });
+
+      if (fallbackResult.worked > Common.capableRenderers || !fallbackResult.resp || !fallbackResult.renderer) {
+        continue;
+      }
+
+      const equationBlob = fallbackResult.resp.getBlob();
+      const result = placeImage(rangeElements[0], equationBlob, fallbackResult.renderer, equationOriginal, equation.options.size, equation.options.delim);
+
+      if (result.status === DocsEquationRenderStatus.Success) {
+        c++;
+      }
+    } catch (error) {
+      console.error("Server fallback render failed.", error);
+    } finally {
+      namedRange?.remove();
+    }
+  }
+
+  return {
+    lastStatus: c > 0 ? DocsEquationRenderStatus.Success : DocsEquationRenderStatus.AllRenderersFailed,
+    successCount: c
+  };
+}
+
 function placeImage(startElement: GoogleAppsScript.Document.RangeElement, renderedEquation: GoogleAppsScript.Base.Blob, renderer: AutoLatexCommon.Renderer, equation: string, size: number, delim: AutoLatexCommon.Delimiter) {
   // GET VARIABLES
   const textElement = startElement.getElement().asText();

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -432,9 +432,9 @@ function getContainingTopLevelChild(
 // What breaks if removed: every multiline equation entered with Enter raises a "End index N
 // must be >= start index M" exception in findPos and the user gets a useless generic error.
 //
-// Limitations: any rich formatting (bold/italic/font/color) on text inside the merged
-// paragraphs is collapsed because appendText only takes a string. We accept that loss because
-// the merged region is the equation itself, which gets replaced by an image anyway.
+// Limitations: rich formatting inside paragraphs that are moved during this auto-fix is not
+// preserved because appendText only takes a string. Formatting is not the failure condition;
+// the paragraph break is.
 function tryAutoMergeMultiParagraphEquation(
   body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection,
   startParaIdx: number,
@@ -473,7 +473,7 @@ function tryAutoMergeMultiParagraphEquation(
     const text = nextPara.getText();
     // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
     // See newlineCharacter comment near top of this file.
-    startPara.appendText("\r" + text);
+    startPara.editAsText().appendText("\r" + text);
     nextPara.removeFromParent();
   }
 
@@ -583,8 +583,8 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
     };
   }
 
-  // Same top-level container but possibly different Text children (e.g., split by inline
-  // image or formatting boundary). Detect by trying the addElement build under a try/catch
+  // Same top-level container but possibly different Text children. Detect by trying
+  // the addElement build under a try/catch
   // so we don't have to fragile-compare element references.
   // REASON: We deliberately wrap *only* the range build in try/catch, not the downstream
   // findEquationAndPlaceImage call. Catching findEquationAndPlaceImage failures here would
@@ -618,7 +618,7 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
         snippet: snippet || "(unknown)",
         hint: isStaleOffset
           ? "This equation could not be located after a prior render. Try clicking 'Render Equations' again — it usually works on the second try."
-          : "This equation appears to cross a formatting boundary or an inline element. Try removing any formatting changes (bold, italic, font, color) inside the $$ delimiters, or remove inline images from the equation."
+          : "This equation appears to contain a paragraph break inside the delimiters. Use Shift+Enter instead of Enter for line breaks inside an equation."
       }
     };
   }

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -15,17 +15,28 @@ const enum DocsEquationRenderStatus {
   AllRenderersFailed,
   ClientRender,
   EmptyEquation,
+  MultiElementEquation,
   NoDocument,
   NoEndDelimiter,
   NoStartDelimiter,
   Success,
 }
 
+// REASON: Carries human-actionable info about a single equation that we couldn't render or
+// auto-fix. The sidebar uses these to tell the user *which* equation broke and *why*, instead
+// of the legacy generic "an equation is incorrect" message.
+interface EquationFailureDetail {
+  reason: string; // short machine-style tag, e.g. "multi-paragraph", "multi-element", "stale-offset"
+  snippet: string; // up to ~80 chars of the equation start so the user can locate it in their doc
+  hint: string;    // user-facing remediation suggestion
+}
+
 interface DocsEquationRenderResult {
   status: DocsEquationRenderStatus,
   equationSize?: number,
   nextStartElement?: GoogleAppsScript.Document.RangeElement,
-  clientRenderOptions?: AutoLatexCommon.ClientRenderOptions
+  clientRenderOptions?: AutoLatexCommon.ClientRenderOptions,
+  failureDetail?: EquationFailureDetail
 }
 
 const DocsApp = {
@@ -174,12 +185,21 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     body = DocumentApp.getActiveDocument();
   } catch (error) {
     console.error(error);
-    
+
     return {
       lastStatus: DocsEquationRenderStatus.NoDocument,
-      successCount: 0
+      successCount: 0,
+      autoFixedCount: 0,
+      failureDetails: [] as EquationFailureDetail[]
     };
   }
+
+  // REASON: Collect every equation we couldn't render so we can return them all to the sidebar
+  // in a single response, instead of dying on the first error and hiding the rest from the user.
+  const failureDetails: EquationFailureDetail[] = [];
+  // REASON: Count of equations we silently auto-recovered (e.g. merged paragraph-split equations).
+  // Surfaced in the sidebar so the user knows we changed their doc on their behalf.
+  let autoFixedCount = 0;
   
   const baseRenderOptions: AutoLatexCommon.RenderOptions = {
     size,
@@ -207,16 +227,27 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     let failedStartElemIfIsEmpty = null;
     while (true) {
       // prevFailedStartElemIfIsEmpty is here so when $$$$ fails again and again, it doesn't get stuck there and moves on.
+      const findPosResult = findPos(index, baseRenderOptions, failedStartElemIfIsEmpty); //or: "\\\$\\\$", "\\\$\\\$"
       const {
         status,
         equationSize,
         nextStartElement,
-        clientRenderOptions
-      } = findPos(index, baseRenderOptions, failedStartElemIfIsEmpty); //or: "\\\$\\\$", "\\\$\\\$"
+        clientRenderOptions,
+        failureDetail
+      } = findPosResult;
 
       if (nextStartElement) failedStartElemIfIsEmpty = nextStartElement;
       // if we found an actual equation, update the default size
       if (equationSize) baseRenderOptions.defaultSize = equationSize;
+
+      // REASON: findPos signals an auto-fix by setting equationSize === -1 in addition to the
+      // regular status. We bump the count and re-run the same index from scratch since the doc
+      // structure changed (paragraphs merged) and any cached RangeElement is now stale.
+      if (status === DocsEquationRenderStatus.Success && equationSize === -1) {
+        autoFixedCount++;
+        failedStartElemIfIsEmpty = null;
+        continue;
+      }
 
       // count consecutive empty equations
       if (status == DocsEquationRenderStatus.EmptyEquation) {
@@ -231,8 +262,19 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
       if (status == DocsEquationRenderStatus.AllRenderersFailed || status == DocsEquationRenderStatus.NoDocument) {
         return {
           lastStatus: status,
-          successCount: c
+          successCount: c,
+          autoFixedCount,
+          failureDetails
         };
+      }
+
+      // REASON: Cross-element / cross-paragraph equations we couldn't auto-fix. Record for the
+      // sidebar and skip past so we don't infinite-loop on the same broken equation.
+      if (status === DocsEquationRenderStatus.MultiElementEquation) {
+        if (failureDetail) failureDetails.push(failureDetail);
+        // failedStartElemIfIsEmpty was set above to nextStartElement (the end delimiter),
+        // so the next findPos call will search after this broken equation.
+        continue;
       }
 
       if (status === DocsEquationRenderStatus.ClientRender && clientRenderOptions) {
@@ -261,13 +303,17 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     return {
       lastStatus: DocsEquationRenderStatus.ClientRender,
       clientEquations: clientRenderBatch,
-      successCount: c
+      successCount: c,
+      autoFixedCount,
+      failureDetails
     };
   }
 
   return {
     lastStatus: DocsEquationRenderStatus.Success,
-    successCount: c
+    successCount: c,
+    autoFixedCount,
+    failureDetails
   };
 }
 
@@ -337,6 +383,112 @@ function findNextDelimiter(
 					1 if eqn is "" and 0 if not. Assume we close on 4 consecutive empty ones.
 */
 
+// REASON: Walk up the parent chain to find the containing top-level body child (Paragraph or
+// ListItem) for a Text element. We need this to detect equations that cross paragraph boundaries
+// (the Enter-instead-of-Shift+Enter case) so we can auto-fix them.
+function getContainingTopLevelChild(
+  element: GoogleAppsScript.Document.Element,
+  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection
+): { topLevelChild: GoogleAppsScript.Document.Element, indexInBody: number } | null {
+  let current: GoogleAppsScript.Document.Element | null = element;
+  while (current != null) {
+    const parent = current.getParent();
+    if (parent == null) {
+      return null;
+    }
+    const parentType = parent.getType();
+    if (parentType === DocumentApp.ElementType.BODY_SECTION ||
+        parentType === DocumentApp.ElementType.HEADER_SECTION ||
+        parentType === DocumentApp.ElementType.FOOTER_SECTION) {
+      try {
+        // ContainerElement already exposes getChildIndex, so no cast needed.
+        const idx = parent.getChildIndex(current);
+        return { topLevelChild: current, indexInBody: idx };
+      } catch (err) {
+        // Stale or detached element
+        return null;
+      }
+    }
+    current = parent;
+  }
+  return null;
+}
+
+// REASON: When findText returns delimiters in different paragraphs, the user almost always
+// pressed Enter instead of Shift+Enter inside a multiline equation. We auto-fix by merging
+// every paragraph from start to end into the start paragraph, joining them with `\r` (the
+// in-paragraph soft line break character that Docs uses for Shift+Enter). The original
+// rendering loop then re-runs findPos and the equation now lives in a single Text element.
+//
+// What breaks if removed: every multiline equation entered with Enter raises a "End index N
+// must be >= start index M" exception in findPos and the user gets a useless generic error.
+//
+// Limitations: any rich formatting (bold/italic/font/color) on text inside the merged
+// paragraphs is collapsed because appendText only takes a string. We accept that loss because
+// the merged region is the equation itself, which gets replaced by an image anyway.
+function tryAutoMergeMultiParagraphEquation(
+  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection,
+  startParaIdx: number,
+  endParaIdx: number
+): { success: boolean, reason: string } {
+  if (endParaIdx <= startParaIdx) {
+    return { success: false, reason: "Paragraph indices out of order" };
+  }
+
+  // Verify every paragraph in the span is a plain Paragraph containing only Text children.
+  // If there are tables, inline images, drawings, etc., merging would either fail outright or
+  // silently destroy user content - safer to bail and show a precise error.
+  for (let i = startParaIdx; i <= endParaIdx; i++) {
+    const child = body.getChild(i);
+    const childType = child.getType();
+    if (childType !== DocumentApp.ElementType.PARAGRAPH) {
+      return { success: false, reason: "Cross-paragraph equation includes a " + childType + " block" };
+    }
+    const para = child.asParagraph();
+    for (let j = 0; j < para.getNumChildren(); j++) {
+      const innerType = para.getChild(j).getType();
+      if (innerType !== DocumentApp.ElementType.TEXT) {
+        return { success: false, reason: "Cross-paragraph equation contains a non-text element (" + innerType + ")" };
+      }
+    }
+  }
+
+  const startPara = body.getChild(startParaIdx).asParagraph();
+  const numToMerge = endParaIdx - startParaIdx;
+
+  // REASON: Forward loop, always grabbing the paragraph immediately after startPara.
+  // After each removeFromParent the indices above startParaIdx all shift down by one, so
+  // (startParaIdx + 1) consistently points at the next paragraph to merge.
+  for (let i = 0; i < numToMerge; i++) {
+    const nextPara = body.getChild(startParaIdx + 1).asParagraph();
+    const text = nextPara.getText();
+    // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
+    // See newlineCharacter comment near top of this file.
+    startPara.appendText("\r" + text);
+    nextPara.removeFromParent();
+  }
+
+  return { success: true, reason: "Merged " + numToMerge + " paragraph(s) with line breaks" };
+}
+
+// REASON: Build a short snippet of the equation start that the user can ctrl-F for in their
+// document. We grab from the start delimiter forward, capping at 80 chars and stopping at the
+// first paragraph break so the snippet stays on one line in the sidebar.
+function buildEquationSnippet(startElement: GoogleAppsScript.Document.RangeElement): string {
+  try {
+    const text = startElement.getElement().asText().getText();
+    const startOffset = startElement.getStartOffset();
+    if (startOffset < 0 || startOffset >= text.length) {
+      return "";
+    }
+    const tail = text.substring(startOffset, Math.min(text.length, startOffset + 80));
+    // Strip line break characters so it renders cleanly in the sidebar
+    return tail.replace(/[\r\n]/g, " ").trim();
+  } catch (err) {
+    return "";
+  }
+}
+
 function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, prevFailedStartElemIfIsEmpty = null): DocsEquationRenderResult {
   Common.debugLog("Checking document section index # ", index);
   Common.reportDeltaTime(195);
@@ -368,19 +520,99 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
   if (placeHolderEnd - placeHolderStart == 2.0) {
     // empty equation
     console.log("Empty equation! In index " + index + " and offset " + placeHolderStart);
-    
+
     return {
       // start from the end element next time to avoid an infinite loop
       nextStartElement: endElement,
       status: DocsEquationRenderStatus.EmptyEquation
     };
   }
-  
-  // build the RangeElement for this equation
-  // we make the assumption that the entire equation is contained within one TextElement
-  const range = DocsApp.getActive().newRange()
-    .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
-    .build();
+
+  // REASON: The legacy assumption was "start and end delimiters live in the same Text element."
+  // That breaks in two real-world cases:
+  //   1. Multi-paragraph equations: user pressed Enter (paragraph break) inside the equation
+  //      instead of Shift+Enter. start and end live in different paragraphs entirely.
+  //   2. Multi-element equations: even within a single paragraph, an inline image or formatting
+  //      change between the delimiters can split the paragraph into multiple Text children.
+  //
+  // Both cases used to throw an uncaught "End index (N) must be >= start index (M)" exception
+  // from addElement, which bubbled up to the sidebar as a generic error.
+  //
+  // Now we detect both cases preemptively, auto-fix case 1 by merging the paragraphs, and
+  // return a precise MultiElementEquation status with a snippet+hint for case 2.
+  const startContainer = getContainingTopLevelChild(startElement.getElement(), docBody);
+  const endContainer = getContainingTopLevelChild(endElement.getElement(), docBody);
+
+  if (startContainer && endContainer && startContainer.indexInBody !== endContainer.indexInBody) {
+    // Cross-paragraph case (1). Try to auto-merge.
+    const snippet = buildEquationSnippet(startElement);
+    console.log("Detected multi-paragraph equation:", JSON.stringify({
+      startParaIdx: startContainer.indexInBody,
+      endParaIdx: endContainer.indexInBody,
+      snippet
+    }));
+    const merge = tryAutoMergeMultiParagraphEquation(docBody, startContainer.indexInBody, endContainer.indexInBody);
+    if (merge.success) {
+      console.log("Auto-fixed multi-paragraph equation:", merge.reason);
+      // REASON: Signal an auto-fix to the caller via equationSize === -1 so the loop
+      // increments autoFixedCount and re-runs findPos against the fresh document state.
+      // We can't recurse here because the caller's `failedStartElemIfIsEmpty` would be stale.
+      return {
+        status: DocsEquationRenderStatus.Success,
+        equationSize: -1
+      };
+    }
+    return {
+      status: DocsEquationRenderStatus.MultiElementEquation,
+      // Skip past the broken end delimiter so we don't loop on it forever
+      nextStartElement: endElement,
+      failureDetail: {
+        reason: "multi-paragraph",
+        snippet: snippet || "(unknown)",
+        hint: "This equation appears to span multiple paragraphs. Inside an equation, use Shift+Enter (line break) instead of Enter (paragraph break). " + merge.reason + "."
+      }
+    };
+  }
+
+  // Same top-level container but possibly different Text children (e.g., split by inline
+  // image or formatting boundary). Detect by trying the addElement build under a try/catch
+  // so we don't have to fragile-compare element references.
+  // REASON: We deliberately wrap *only* the range build in try/catch, not the downstream
+  // findEquationAndPlaceImage call. Catching findEquationAndPlaceImage failures here would
+  // hide unrelated bugs (network/render failures) behind a generic "multi-element" message.
+  let range: GoogleAppsScript.Document.Range;
+  try {
+    range = DocsApp.getActive().newRange()
+      .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
+      .build();
+  } catch (rangeErr) {
+    const snippet = buildEquationSnippet(startElement);
+    console.warn("Could not build equation range:", JSON.stringify({
+      error: String(rangeErr),
+      startOffset: startElement.getStartOffset(),
+      endOffset: endElement.getEndOffsetInclusive(),
+      snippet
+    }));
+    // REASON: Distinguish "stale offsets after a prior mutation" from "real cross-element"
+    // by inspecting the error message. Stale-offset errors look like "Index (N) must be less
+    // than the content length (M)" — these happen when an earlier render moved text under us
+    // and the user can usually fix them just by re-running the renderer. Cross-element errors
+    // look like "End index (N) must be greater or equal to start index (M)" — these need a
+    // structural fix in the doc.
+    const errMsg = String(rangeErr || "");
+    const isStaleOffset = /Index \([0-9]+\) must be less than/.test(errMsg) || /less than the content length/.test(errMsg);
+    return {
+      status: DocsEquationRenderStatus.MultiElementEquation,
+      nextStartElement: endElement,
+      failureDetail: {
+        reason: isStaleOffset ? "stale-offset" : "multi-element",
+        snippet: snippet || "(unknown)",
+        hint: isStaleOffset
+          ? "This equation could not be located after a prior render. Try clicking 'Render Equations' again — it usually works on the second try."
+          : "This equation appears to cross a formatting boundary or an inline element. Try removing any formatting changes (bold, italic, font, color) inside the $$ delimiters, or remove inline images from the equation."
+      }
+    };
+  }
 
   return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
 }
@@ -814,42 +1046,59 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
   const defaultDelim = Common.getDelimiters(delimiter);
   Common.savePrefs(sizeRaw, delimiter, renderer);
   const cursor = DocumentApp.getActiveDocument().getCursor();
-  if (cursor) {
-    // Attempt to insert text at the cursor position. If the insertion returns null, the cursor's
-    // containing element doesn't allow insertions, so show the user an error message.
-    const element = cursor.getElement() as GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph; //startElement
-
-    if (element) {
-      console.log("Valid cursor.");
-
-      const position = cursor.getOffset(); //offset
-      if (position >= element.getNumChildren()) {
-        return Common.DerenderResult.CursorNotFound;
-      }
-      //element.getChild(position).removeFromParent();  //SUCCESSFULLY REMOVES IMAGE FROM PARAGRAPH
-      // console.log(element.getAllContent(), element.type())
-      const image = element.getChild(position).asInlineImage();
-      Common.debugLog("Image height", image.getHeight());
-      const origURL = image.getLinkUrl();
-      if (!origURL) {
-        return Common.DerenderResult.NullUrl;
-      }
-      Common.debugLog("Original URL from image", origURL);
-      const result = Common.derenderEquation(origURL, DocsApp);
-      if (!result) return Common.DerenderResult.InvalidUrl;
-      const { delim: newDelim, origEq } = result;
-      const delim = newDelim || defaultDelim;
-      if (origEq.length <= 0) {
-        console.log("Empty equation derender.");
-        return Common.DerenderResult.EmptyEquation;
-      }
-      cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
-      element.getChild(position + 1).removeFromParent();
-      return Common.DerenderResult.Success;
-    } else {
-      return Common.DerenderResult.NonExistentElement;
-    }
-  } else {
+  if (!cursor) {
     return Common.DerenderResult.CursorNotFound;
   }
+
+  const elementRaw = cursor.getElement();
+  if (!elementRaw) {
+    return Common.DerenderResult.NonExistentElement;
+  }
+
+  // REASON: Cursor.getElement() can return any Element subtype (Table, TableOfContents,
+  // FootnoteSection, etc.) - not just Paragraph/ListItem. The previous code did an unchecked
+  // `as ListItem | Paragraph` cast and then called .getNumChildren(), which crashed with
+  // "TypeError: element.getNumChildren is not a function" for users whose cursor was inside
+  // a table cell or footnote. Validate the element type up front.
+  const elementType = elementRaw.getType();
+  if (elementType !== DocumentApp.ElementType.PARAGRAPH && elementType !== DocumentApp.ElementType.LIST_ITEM) {
+    console.log("editEquations: cursor is in unsupported element type", elementType);
+    return Common.DerenderResult.NonExistentElement;
+  }
+
+  const element = elementRaw as GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph;
+  console.log("Valid cursor.");
+
+  const position = cursor.getOffset(); //offset
+  if (position >= element.getNumChildren()) {
+    return Common.DerenderResult.CursorNotFound;
+  }
+
+  // REASON: getChild(position).asInlineImage() throws "TEXT can't be cast to INLINE_IMAGE"
+  // when the user's cursor is on text instead of an equation image. Check the child type
+  // first and return a precise status so the sidebar can tell them to click the image.
+  const childAtCursor = element.getChild(position);
+  if (childAtCursor.getType() !== DocumentApp.ElementType.INLINE_IMAGE) {
+    console.log("editEquations: child at cursor is not an inline image", childAtCursor.getType());
+    return Common.DerenderResult.NonExistentElement;
+  }
+
+  const image = childAtCursor.asInlineImage();
+  Common.debugLog("Image height", image.getHeight());
+  const origURL = image.getLinkUrl();
+  if (!origURL) {
+    return Common.DerenderResult.NullUrl;
+  }
+  Common.debugLog("Original URL from image", origURL);
+  const result = Common.derenderEquation(origURL, DocsApp);
+  if (!result) return Common.DerenderResult.InvalidUrl;
+  const { delim: newDelim, origEq } = result;
+  const delim = newDelim || defaultDelim;
+  if (origEq.length <= 0) {
+    console.log("Empty equation derender.");
+    return Common.DerenderResult.EmptyEquation;
+  }
+  cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+  element.getChild(position + 1).removeFromParent();
+  return Common.DerenderResult.Success;
 }

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -40,26 +40,33 @@ interface DocsEquationRenderResult {
   failureDetail?: EquationFailureDetail
 }
 
-const DocsApp = {
-	getUi: function(){
-		let activeUi = DocumentApp.getUi();
-		return activeUi;
-	},
-	getBody: function(){
-		let activeBody = DocumentApp.getActiveDocument().getBody();
-		return activeBody;
-	},
-	getActive: function(){
-		let activeDoc = DocumentApp.getActiveDocument();
-		return activeDoc;
-	},
-	getPageWidth: function() {
-		let activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
-		return activeWidth;
-	},
-	// A \n in Docs represents a paragraph break, while a \r (\x0D) represents a break within a paragraph
-	newlineCharacter: "%0D"
-} satisfies AutoLatexCommon.IntegratedApp;
+interface DocsIntegratedApp extends AutoLatexCommon.IntegratedApp {
+  getActive(): GoogleAppsScript.Document.Document;
+  getBody(): GoogleAppsScript.Document.Body;
+}
+
+function getDocsApp(): DocsIntegratedApp {
+  return {
+    getUi: function(){
+      let activeUi = DocumentApp.getUi();
+      return activeUi;
+    },
+    getBody: function(){
+      let activeBody = DocumentApp.getActiveDocument().getBody();
+      return activeBody;
+    },
+    getActive: function(){
+      let activeDoc = DocumentApp.getActiveDocument();
+      return activeDoc;
+    },
+    getPageWidth: function() {
+      let activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
+      return activeWidth;
+    },
+    // A \n in Docs represents a paragraph break, while a \r (\x0D) represents a break within a paragraph
+    newlineCharacter: "%0D"
+  };
+}
 
 
 /** //8.03 - De-Render, Inline, Advanced Delimiters > Fixed Inline Not Appearing
@@ -71,7 +78,7 @@ const DocsApp = {
  */
 function onOpen(_e: object) {
   try {
-    DocsApp.getUi().createAddonMenu().addItem("Start", "showSidebar").addToUi();
+    DocumentApp.getUi().createAddonMenu().addItem("Start", "showSidebar").addToUi();
   } catch (error) {
     // Manual runs from the Apps Script editor do not have a document UI context.
     console.warn("Skipping onOpen outside a Docs UI context.", error);
@@ -99,7 +106,7 @@ function showSidebar() {
     .setTitle("Auto-LaTeX Equations")
     .setSandboxMode(HtmlService.SandboxMode.IFRAME) // choose mode IFRAME which is fastest option
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL); // allow third party Docs clients
-  DocsApp.getUi().showSidebar(ui);
+  DocumentApp.getUi().showSidebar(ui);
 }
 
 /**
@@ -591,7 +598,7 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
   // hide unrelated bugs (network/render failures) behind a generic "multi-element" message.
   let range: GoogleAppsScript.Document.Range;
   try {
-    range = DocsApp.getActive().newRange()
+    range = getDocsApp().getActive().newRange()
       .addElement(startElement.getElement().asText(), startElement.getStartOffset(), endElement.getEndOffsetInclusive())
       .build();
   } catch (rangeErr) {
@@ -637,7 +644,7 @@ function getEquation(rangeElement: GoogleAppsScript.Document.RangeElement, delim
       rangeElement.getStartOffset() + delimiters[4], rangeElement.getEndOffsetInclusive() - delimiters[4] + 1
     );
   Common.debugLog("See equation", equation);
-  const equationStringEncoded = Common.reEncode(equation, DocsApp); //escape deprecated
+  const equationStringEncoded = Common.reEncode(equation, getDocsApp()); //escape deprecated
   Common.reportDeltaTime(290);
   //console.log("Encoded: " + equationStringEncoded);
   return equationStringEncoded;
@@ -685,7 +692,7 @@ function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRender
   for (const equation of equations) {
     let namedRange: GoogleAppsScript.Document.NamedRange | null = null;
     try {
-      namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+      namedRange = getDocsApp().getActive().getNamedRangeById(equation.options.rangeId);
       if (!namedRange) {
         console.warn("MathJax client render range disappeared before completion:", equation.options.rangeId);
         continue;
@@ -845,7 +852,7 @@ function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOp
   for (const equation of equations) {
     let namedRange: GoogleAppsScript.Document.NamedRange | null = null;
     try {
-      namedRange = DocsApp.getActive().getNamedRangeById(equation.options.rangeId);
+      namedRange = getDocsApp().getActive().getNamedRangeById(equation.options.rangeId);
       if (!namedRange) {
         console.warn("Server fallback: range disappeared:", equation.options.rangeId);
         continue;
@@ -857,7 +864,7 @@ function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOp
         continue;
       }
 
-      const equationOriginal = Common.reEncode(equation.options.equation, DocsApp);
+      const equationOriginal = Common.reEncode(equation.options.equation, getDocsApp());
 
       // REASON: Try Texrendr and Sciweavers only - Codecogs already failed, MathJax already failed.
       const fallbackResult = renderEquationWithCompatibility(equationOriginal, {
@@ -991,7 +998,7 @@ function repairImage(paragraph: GoogleAppsScript.Document.ListItem | GoogleAppsS
     multiple = 1.26 / 5;
 
   Common.reportDeltaTime(595);
-  Common.sizeImage(DocsApp, paragraph, childIndex + 1, Math.round(height * multiple), Math.round(width * multiple));
+  Common.sizeImage(getDocsApp(), paragraph, childIndex + 1, Math.round(height * multiple), Math.round(width * multiple));
   
   return {
     status: DocsEquationRenderStatus.Success,
@@ -1000,7 +1007,7 @@ function repairImage(paragraph: GoogleAppsScript.Document.ListItem | GoogleAppsS
 }
 
 function getBodyFromIndex(index: number) {
-  const doc = DocsApp.getActive();
+  const doc = getDocsApp().getActive();
   const p = doc.getBody().getParent();
   const all = p.getNumChildren();
   Common.assert(index < all, "index < all");
@@ -1021,7 +1028,7 @@ function removeAll(defaultDelimRaw: string) {
   let counter = 0;
   const defaultDelim = Common.getDelimiters(defaultDelimRaw);
   
-  for (var index = 0; index < DocsApp.getBody().getParent().getNumChildren(); index++) {
+  for (var index = 0; index < getDocsApp().getBody().getParent().getNumChildren(); index++) {
     const body = getBodyFromIndex(index);
     const img = body?.getImages(); //places all InlineImages from the active document into the array img
     for (let i = 0; i < (img?.length || 0); i++) {
@@ -1032,7 +1039,7 @@ function removeAll(defaultDelimRaw: string) {
       }
       // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
       // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-      const result = Common.derenderEquation(origURL, DocsApp);
+      const result = Common.derenderEquation(origURL, getDocsApp());
       if (!result) continue;
       const { origEq, delim: newDelim } = result;
       const delim = newDelim || defaultDelim;
@@ -1107,7 +1114,7 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
     return Common.DerenderResult.NullUrl;
   }
   Common.debugLog("Original URL from image", origURL);
-  const result = Common.derenderEquation(origURL, DocsApp);
+  const result = Common.derenderEquation(origURL, getDocsApp());
   if (!result) return Common.DerenderResult.InvalidUrl;
   const { delim: newDelim, origEq } = result;
   const delim = newDelim || defaultDelim;

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -13,6 +13,7 @@ var DEBUG = false; //doing ctrl + m to get key to see errors is still needed; DE
  */
 const enum DocsEquationRenderStatus {
   AllRenderersFailed,
+  AuthorizationFailed,
   ClientRender,
   EmptyEquation,
   MultiElementEquation,
@@ -259,7 +260,9 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
       if (allEmpty > 10) break; //Assume we quit on 10 consecutive empty equations.
 
       // quit if all renderers failed or if document failed to load (conflicting authorizations)
-      if (status == DocsEquationRenderStatus.AllRenderersFailed || status == DocsEquationRenderStatus.NoDocument) {
+      if (status == DocsEquationRenderStatus.AllRenderersFailed ||
+          status == DocsEquationRenderStatus.AuthorizationFailed ||
+          status == DocsEquationRenderStatus.NoDocument) {
         return {
           lastStatus: status,
           successCount: c,
@@ -776,9 +779,9 @@ function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.Range
     return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
   }
 
-  let { resp, renderer, worked } = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions);
+  let { resp, renderer, worked, authorizationError } = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions);
   if (worked > Common.capableRenderers || !resp || !renderer) return {
-    status: DocsEquationRenderStatus.AllRenderersFailed
+    status: authorizationError ? DocsEquationRenderStatus.AuthorizationFailed : DocsEquationRenderStatus.AllRenderersFailed
   };
   // SAVING FORMATTING
   Common.reportDeltaTime(511);
@@ -827,6 +830,7 @@ function buildClientRenderResponse(
  */
 function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOptions }[]) {
   let c = 0;
+  let authorizationFailure = false;
   console.log("MathJax client render failed, trying server fallback for", equations.length, "equations");
 
   // Go backwards so that the named ranges for multiple equations in the same paragraph don't get removed
@@ -863,6 +867,9 @@ function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOp
       });
 
       if (fallbackResult.worked > Common.capableRenderers || !fallbackResult.resp || !fallbackResult.renderer) {
+        if (fallbackResult.authorizationError) {
+          authorizationFailure = true;
+        }
         continue;
       }
 
@@ -880,7 +887,11 @@ function clientRenderFailed(equations: { options: AutoLatexCommon.ClientRenderOp
   }
 
   return {
-    lastStatus: c > 0 ? DocsEquationRenderStatus.Success : DocsEquationRenderStatus.AllRenderersFailed,
+    lastStatus: c > 0
+      ? DocsEquationRenderStatus.Success
+      : authorizationFailure
+        ? DocsEquationRenderStatus.AuthorizationFailed
+        : DocsEquationRenderStatus.AllRenderersFailed,
     successCount: c
   };
 }

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -351,15 +351,21 @@ function isSingleDollarDelimiter(rangeElement: GoogleAppsScript.Document.RangeEl
   return true;
 }
 
+// REASON: delimIdx picks delim[2] (start regex) vs delim[3] (end regex).
+// For asymmetric delimiters like `\[ ... \]` and `\( ... \)` the start and end patterns differ,
+// so using delim[2] for both (the original bug) caused the end-search to look for another `\[`
+// instead of `\]`, find none, and report "no equations found." For `$ ... $` the two are the
+// same regex so either index works; isSingleDollarDelimiter still filters out `$$` / `\$` cases.
 function findNextDelimiter(
   docBody: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection,
   renderOptions: AutoLatexCommon.RenderOptions,
-  fromRange: GoogleAppsScript.Document.RangeElement | null = null
+  fromRange: GoogleAppsScript.Document.RangeElement | null = null,
+  delimIdx: 2 | 3 = 2
 ) {
   if (renderOptions.delim[6] !== 2) {
     return fromRange == null
-      ? docBody.findText(renderOptions.delim[2])
-      : docBody.findText(renderOptions.delim[2], fromRange);
+      ? docBody.findText(renderOptions.delim[delimIdx])
+      : docBody.findText(renderOptions.delim[delimIdx], fromRange);
   }
 
   let candidate = fromRange == null ? docBody.findText("\\$") : docBody.findText("\\$", fromRange);
@@ -501,7 +507,7 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
       status: DocsEquationRenderStatus.NoDocument
     };
   }
-  const startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty);
+  const startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty, 2);
   if (startElement == null) {
     return {
       status: DocsEquationRenderStatus.NoStartDelimiter
@@ -509,7 +515,7 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
   }
   const placeHolderStart = startElement.getStartOffset(); //position of image insertion
 
-  const endElement = findNextDelimiter(docBody, renderOptions, startElement);
+  const endElement = findNextDelimiter(docBody, renderOptions, startElement, 3);
   // could not find the ending delimiter after the start
   if (endElement == null) {
     return {

--- a/Docs/Sidebar.html
+++ b/Docs/Sidebar.html
@@ -4,15 +4,13 @@
     <base target="_top" />
     <meta charset="utf-8" />
     <title>Auto-Latex Equations</title>
-    <!-- Google Analytics -->
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R3YH8795TS"></script>
     <script>
-      //    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      //    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      //    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      //    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      //
-      //    ga('create', 'UA-XXXXX-Y', 'auto');
-      //    ga('send', 'pageview');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R3YH8795TS');
     </script>
     <!-- End Google Analytics -->
 

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -26,6 +26,7 @@ const reportedMathJaxErrors = new Set<string>();
 let isMathJaxRenderChaining = false;
 let mathJaxRenderedCount = 0;
 let activeSidebarActionId = 0;
+let autoFixRerenderAttempted = false;
 const RENDER_BUTTON_LABEL = "Render Equations";
 const STOP_RENDER_BUTTON_LABEL = "Stop Rendering";
 const DONATE_CLICKED_STORAGE_KEY = "ale-docs-donate-clicked";
@@ -521,6 +522,18 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
       resetMathJaxRenderProgress();
     }
 
+    if (lastStatus === google.script.DocsEquationRenderStatus.Success &&
+        successCount === 0 &&
+        lastReplaceAutoFixedCount > 0 &&
+        lastReplaceFailureDetails.length === 0 &&
+        !autoFixRerenderAttempted) {
+      autoFixRerenderAttempted = true;
+      lastReplaceAutoFixedCount = 0;
+      $("#loading").html("Auto-fixed multiline equation. Rendering again...");
+      requestNextMathJaxBatch(element, actionId);
+      return;
+    }
+
     $("#loading").html('');
     restoreIdleSidebarControls();
 
@@ -582,6 +595,7 @@ function insertText(){
     return;
   }
   const actionId = beginSidebarAction();
+  autoFixRerenderAttempted = false;
   const {sizeRaw, delimiter, renderer} = getCurrentSettings();
   if (renderer === "mathjax") {
     isMathJaxRenderChaining = true;

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -58,7 +58,8 @@ function normalizeError(error: unknown) {
 
 function shouldLogMathJaxErrors() {
   try {
-    return getCurrentSettings().renderer === "mathjax";
+    const renderer = getCurrentSettings().renderer;
+    return renderer === "mathjax" || renderer === "auto";
   } catch {
     return false;
   }
@@ -197,11 +198,30 @@ window.addEventListener("unhandledrejection", event => {
   reportMathJaxClientError("window.unhandledrejection", event.reason);
 });
 
+// REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in parallel
+// (e.g. 1000 equations) would freeze the browser. This limits concurrency to a safe number.
+const MATHJAX_CONCURRENCY_LIMIT = 4;
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
 /**
 * Convert a Blob to a base64 string for transmission to the server
-* 
+*
 * @param blob the blob to convert
-* @returns 
+* @returns
 */
 async function blobToB64(blob: Blob) {
   const dataUrl = await new Promise<string>((resolve, reject) => {
@@ -394,9 +414,17 @@ function successHandler({ lastStatus, successCount, clientEquations }: { lastSta
     return;
   }
   if (lastStatus === google.script.DocsEquationRenderStatus.ClientRender) {
+    // REASON: In auto mode, enable chaining lazily when we first need client rendering.
+    // This avoids an unnecessary extra round-trip when all equations succeed with Codecogs.
+    if (!isMathJaxRenderChaining) {
+      isMathJaxRenderChaining = true;
+      mathJaxRenderedCount = successCount; // count any server-side (Codecogs) successes
+      setRenderButtonState(true);
+    }
+
     // we're not done yet - these equations need to be rendered on the client
     const equationsToRender = clientEquations || [];
-    Promise.all(equationsToRender.map(async c => ({ options: c, renderedEquationB64: await renderMathJaxEquation(c).then(b => blobToB64(b)) })))
+    mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async c => ({ options: c, renderedEquationB64: await renderMathJaxEquation(c).then(b => blobToB64(b)) }))
       .then(rendered => {
         if (isStaleSidebarAction(actionId)) {
           return;
@@ -409,7 +437,20 @@ function successHandler({ lastStatus, successCount, clientEquations }: { lastSta
       })
       .catch(err => {
         reportMathJaxClientError("clientRenderBatch", err, { equationCount: equationsToRender.length });
-        errorHandler(err, element, actionId);
+        // REASON: In auto mode, if MathJax fails, try remaining server renderers (Texrendr/Sciweavers)
+        // instead of showing an error immediately.
+        if (getCurrentSettings().renderer === "auto") {
+          if (isStaleSidebarAction(actionId)) {
+            return;
+          }
+          google.script.run
+            .withSuccessHandler((result, userObject) => successHandler(result, userObject, actionId))
+            .withFailureHandler((msg, userObject) => errorHandler(msg, userObject, actionId))
+            .withUserObject(element)
+            .clientRenderFailed(equationsToRender.map(c => ({ options: c })));
+        } else {
+          errorHandler(err, element, actionId);
+        }
       });
   } else {
     const roundSuccessCount = successCount;

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -17,7 +17,11 @@ interface Window {
 declare const MathJax: MathJaxApi;
 
 // animation timeout ID
-let runDots = -1;
+// REASON: setInterval return type conflicts between DOM lib (number) and Node @types
+// (Timeout) when both are in scope during Sidebar.ts compilation. The runtime contract is
+// "either a setInterval handle or the -1 sentinel meaning 'no animation'", and clearInterval
+// accepts both. Use a permissive type so the build doesn't break on the declaration mismatch.
+let runDots: any = -1;
 const reportedMathJaxErrors = new Set<string>();
 let isMathJaxRenderChaining = false;
 let mathJaxRenderedCount = 0;
@@ -409,10 +413,63 @@ function makeStatusText(successCount: number) {
   else return `Status: ${successCount} equations rendered`;
 }
 
-function successHandler({ lastStatus, successCount, clientEquations }: { lastStatus: google.script.DocsEquationRenderStatus, successCount: number, clientEquations?: AutoLatexCommon.ClientRenderOptions[] }, element: HTMLButtonElement, actionId: number) {
+// REASON: Track the most recent server response so client-side fallback paths
+// (MathJax round-trips, Texrendr/Sciweavers retries) can carry forward the auto-fix
+// count and any equation failures the server already detected. Without this,
+// successive calls would reset the counts and the user would never see them.
+let lastReplaceFailureDetails: AutoLatexCommon.EquationFailureDetail[] = [];
+let lastReplaceAutoFixedCount = 0;
+
+interface ReplaceEquationsResult {
+  lastStatus: google.script.DocsEquationRenderStatus,
+  successCount: number,
+  clientEquations?: AutoLatexCommon.ClientRenderOptions[],
+  autoFixedCount?: number,
+  failureDetails?: AutoLatexCommon.EquationFailureDetail[]
+}
+
+// REASON: Build a single HTML message that summarises every equation we couldn't render and
+// the precise hint for each one. Up to 5 equations are shown verbatim; anything beyond that
+// is collapsed into a count so the sidebar doesn't blow up vertically.
+function buildFailureDetailsHtml(failureDetails: AutoLatexCommon.EquationFailureDetail[]): string {
+  if (!failureDetails || failureDetails.length === 0) return "";
+  const escape = (s: string) => String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+  const maxShown = 5;
+  const shown = failureDetails.slice(0, maxShown);
+  const items = shown.map(detail => {
+    const snippet = detail.snippet ? `<code>${escape(detail.snippet)}</code>` : "<em>(unknown location)</em>";
+    return `<li>${snippet}<br><span class="ale-error-hint">${escape(detail.hint || "")}</span></li>`;
+  }).join("");
+  const remainder = failureDetails.length - shown.length;
+  const more = remainder > 0 ? `<div class="ale-error-more">…and ${remainder} more equation${remainder === 1 ? "" : "s"} with similar issues.</div>` : "";
+  return `<div class="ale-failure-list"><strong>${failureDetails.length} equation${failureDetails.length === 1 ? "" : "s"} could not be rendered:</strong><ul>${items}</ul>${more}</div>`;
+}
+
+function buildAutoFixedNote(autoFixedCount: number): string {
+  if (!autoFixedCount || autoFixedCount <= 0) return "";
+  return `<div class="ale-autofix-note">Auto-fixed ${autoFixedCount} multiline equation${autoFixedCount === 1 ? "" : "s"} (replaced paragraph breaks with line breaks inside the equation${autoFixedCount === 1 ? "" : "s"}).</div>`;
+}
+
+function successHandler({ lastStatus, successCount, clientEquations, autoFixedCount, failureDetails }: ReplaceEquationsResult, element: HTMLButtonElement, actionId: number) {
   if (isStaleSidebarAction(actionId)) {
     return;
   }
+
+  // REASON: The server may produce auto-fix counts and failure details on this round and on
+  // any future client-side round-trip (MathJax, Texrendr fallback). Accumulate them across
+  // rounds so the final summary in the sidebar is complete.
+  if (typeof autoFixedCount === "number" && autoFixedCount > 0) {
+    lastReplaceAutoFixedCount += autoFixedCount;
+  }
+  if (failureDetails && failureDetails.length > 0) {
+    lastReplaceFailureDetails = lastReplaceFailureDetails.concat(failureDetails);
+  }
+
   if (lastStatus === google.script.DocsEquationRenderStatus.ClientRender) {
     // REASON: In auto mode, enable chaining lazily when we first need client rendering.
     // This avoids an unnecessary extra round-trip when all equations succeed with Codecogs.
@@ -466,16 +523,31 @@ function successHandler({ lastStatus, successCount, clientEquations }: { lastSta
 
     $("#loading").html('');
     restoreIdleSidebarControls();
-    
+
     const statusText = makeStatusText(successCount);
-    
-    if (lastStatus === google.script.DocsEquationRenderStatus.NoDocument)
-      showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", statusText);
-    else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount > 0)
-      showError("Sorry, an equation is incorrect, or (temporarily) unavailable commands (i.e. align, &) were used.", statusText);
-    else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount === 0)
-      showError("Sorry, likely (temporarily) unavailable commands (i.e. align, &) were used or the equation was too long.", statusText);
-    else {
+    const autoFixHtml = buildAutoFixedNote(lastReplaceAutoFixedCount);
+    const failureHtml = buildFailureDetailsHtml(lastReplaceFailureDetails);
+    // Reset accumulators now that we're rendering the final summary for this run.
+    const accumulatedFailures = lastReplaceFailureDetails;
+    lastReplaceFailureDetails = [];
+    lastReplaceAutoFixedCount = 0;
+
+    if (lastStatus === google.script.DocsEquationRenderStatus.NoDocument) {
+      showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts." + autoFixHtml + failureHtml, statusText);
+    } else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount > 0) {
+      showError("Sorry, an equation is incorrect, or (temporarily) unavailable commands (i.e. align, &) were used." + autoFixHtml + failureHtml, statusText);
+    } else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount === 0) {
+      showError("Sorry, likely (temporarily) unavailable commands (i.e. align, &) were used or the equation was too long." + autoFixHtml + failureHtml, statusText);
+    } else if (accumulatedFailures.length > 0) {
+      // REASON: We rendered some equations successfully but skipped others with structural
+      // issues (multi-paragraph or multi-element). Show a precise breakdown so the user knows
+      // exactly which equations need a manual fix.
+      showError("Some equations could not be rendered automatically." + autoFixHtml + failureHtml, statusText);
+    } else if (autoFixHtml) {
+      // Pure auto-fix success: surface a soft note instead of an error so the user knows we
+      // touched their doc, but doesn't see a scary red error block.
+      $("#loading").html(statusText + autoFixHtml);
+    } else {
       $("#loading").html(statusText);
     }
   }
@@ -490,7 +562,17 @@ function errorHandler(msg, element, actionId: number) {
   restoreIdleSidebarControls();
   console.error("Error console errored!", msg, element);
   reportMathJaxClientError("sidebar.errorHandler", msg);
-  showError("<strong>Ensure you clicked 'Select all' on the permissions screen. If not, try uninstalling and reinstalling the add-on to redo permissions.</strong> Please ensure your equations are surrounded by $$ on both sides (or \\[ and an \\]), without any enters in between, or reload the page. If authorization required, try signing out of other google accounts.", "Status: Error, please reload.");
+
+  // REASON: If the server already detected and reported some equation failures before throwing
+  // (e.g. it auto-fixed three multiline equations and then a fourth one hit an unrelated bug),
+  // surface those auto-fixes and failure details to the user instead of dropping them on the
+  // floor with the legacy generic message.
+  const autoFixHtml = buildAutoFixedNote(lastReplaceAutoFixedCount);
+  const failureHtml = buildFailureDetailsHtml(lastReplaceFailureDetails);
+  lastReplaceFailureDetails = [];
+  lastReplaceAutoFixedCount = 0;
+
+  showError("<strong>Ensure you clicked 'Select all' on the permissions screen. If not, try uninstalling and reinstalling the add-on to redo permissions.</strong> Please ensure your equations are surrounded by $$ on both sides (or \\[ and an \\]), without any enters in between (use Shift+Enter for line breaks inside an equation), or reload the page. If authorization required, try signing out of other google accounts." + autoFixHtml + failureHtml, "Status: Error, please reload.");
 }
   
 function insertText(){ 
@@ -545,7 +627,12 @@ function editText(){
             showError("Cannot retrieve equation. Is your cursor before an Auto-LaTeX rendered equation?", "Status: Error, please move cursor before inline equation.");
             break;
           case AutoLatexCommon.DerenderResult.NonExistentElement:
-            showError("Cannot insert text here. Is your cursor before an equation?", "Status: Error, please move cursor before equation.");
+            // REASON: This status now also covers two distinct cases the server defensively
+            // detects: (a) the cursor is on plain text instead of on the equation image, and
+            // (b) the cursor is inside an unsupported element type (table cell, footnote,
+            // table of contents). Both used to crash with a TypeError. The combined hint
+            // covers both without forcing a new enum value.
+            showError("Place your cursor immediately before the rendered equation image and try again. De-render only works on equations rendered by Auto-LaTeX inside a normal paragraph - it doesn't work inside tables, footnotes, or on plain text.", "Status: Error, please move cursor before the equation image.");
             break;
           case AutoLatexCommon.DerenderResult.CursorNotFound:
             showError("Cannot find a cursor/equation. Please click before an equation.", "Status: Error, please move cursor before equation.");

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -534,6 +534,8 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
 
     if (lastStatus === google.script.DocsEquationRenderStatus.NoDocument) {
       showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts." + autoFixHtml + failureHtml, statusText);
+    } else if (lastStatus === google.script.DocsEquationRenderStatus.AuthorizationFailed) {
+      showError("<strong>Auto-LaTeX is missing permission to call external renderers.</strong> Try uninstalling and reinstalling the add-on, then click 'Select all' on the permissions screen. The equation may be valid; Google has not granted the add-on external request access yet." + autoFixHtml + failureHtml, statusText);
     } else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount > 0) {
       showError("Sorry, an equation is incorrect, or (temporarily) unavailable commands (i.e. align, &) were used." + autoFixHtml + failureHtml, statusText);
     } else if (lastStatus === google.script.DocsEquationRenderStatus.AllRenderersFailed && successCount === 0) {

--- a/Docs/appsscript.json
+++ b/Docs/appsscript.json
@@ -12,7 +12,7 @@
       {
         "userSymbol": "Common",
         "version": "0",
-        "libraryId": "",
+        "libraryId": "1uvjXsMOV3WRrN6wEFVDVEuuc7-ygpMynvy1B1Dy4AOoWXBrQa4Cu4ZA7",
         "developmentMode": true
       }
     ]

--- a/Docs/appsscript.json
+++ b/Docs/appsscript.json
@@ -1,13 +1,6 @@
 {
   "timeZone": "America/Los_Angeles",
   "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Analytics",
-        "serviceId": "analytics",
-        "version": "v3"
-      }
-    ],
     "libraries": [
       {
         "userSymbol": "Common",

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ You need to get the .clasp.json files within Docs/, Slides/, and Sheets/ by dm'i
 
 clasp is used to sync your local folder with the actual code sandbox in the Google Doc/Slide/whatever that's eventually published. We use Github for development with multiple people. You can use clasp to live update the code in the Google sandbox so you dont have to deal with push/pull anymore. More info at https://www.toptal.com/google-docs/extending-google-sheets-app-scripts.
 
-For the Common library, you can use `clasp push -w` to watch for changes and push them to this library. Dependent Apps Script projects will automatically use the development version of the library.
+For the Common library, use `npm -w Common run clasp-push` so the generated `.js` files exist before upload. Dependent Apps Script projects will automatically use the development version of the library.
 
 For any projects which depend on the Common library (Slides and Docs), the Common project ID must be added to the manifest file. The `LibraryLinker` script does this for you, and is called when using the `clasp-push` NPM script in Slides and Docs. (This script links the library, runs `clasp push`, then unlinks the library.)
 
-Therefore, to push changes to Slides and Docs, instead of using `clasp-push`, use `npm run clasp-push` in the respective directory, or use the workspace name in the root directory. (e.g. `npm -w Slides run clasp-push`)
+Therefore, to push changes to Slides and Docs, instead of using raw `clasp push`, use `npm run clasp-push` in the respective directory, or use the workspace name in the root directory. (e.g. `npm -w Slides run clasp-push`)
 
 If you would like to watch for changes, `npm -w Slides/Docs run clasp-push -- -w` will pass the `-w` flag to `clasp push`.
 
 **However**, `Ctrl+C`'ing the watch will not run the `postclasp-push` script, meaning the Common library will stay linked to the dependent project. To fix this, run `npm -w Slides/Docs run postclasp-push` after stopping the watch.
+
+Agent note: if Codex or Claude Code is handling a push or deployment task, have it read [skills/apps-script-push/SKILL.md](skills/apps-script-push/SKILL.md) first. That file documents the supported push commands, linker behavior, sidebar rebuild requirements, remote verification, and the difference between project head and versioned deployments.
 
 ## Types
 
@@ -39,7 +41,7 @@ To get types for google.script.run, the sidebar JS must be contained in its own 
 
 1. Ensure `.clasp.json` points to the production script project (the script ID should match the one in the URL bar on `script.google.com`)
 2. Set `DEBUG` to `false` in Code.ts
-3. Run `clasp push`
+3. Run `npm run clasp-push`
 4. Open the project on `script.google.com` (Auto-Latex Equations: Common library)
 5. Click Deploy -> New deployment
 6. Select the "Library" type

--- a/Sheets/Code.js
+++ b/Sheets/Code.js
@@ -910,6 +910,9 @@ function getDelimiters(delimiters) {
   if (delimiters == "$") {
     return ["$", "$", "[^\\\\]\\$", "[^\\\\]\\$", 1, 0, 2];
   } //(^|[^\\$])\$(?!\$) //(?:^|[^\\\\\\])\\\$ //[^\\\\]\\\$
+  if (delimiters == "(") {
+    return ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3];
+  }
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
 }
 
@@ -923,6 +926,9 @@ function getNumDelimiters(delimiters) {
   }
   if (delimiters == "2") {
     return "$";
+  }
+  if (delimiters == "3") {
+    return "(";
   }
   return "$$";
 }

--- a/Sheets/Code.js
+++ b/Sheets/Code.js
@@ -910,9 +910,6 @@ function getDelimiters(delimiters) {
   if (delimiters == "$") {
     return ["$", "$", "[^\\\\]\\$", "[^\\\\]\\$", 1, 0, 2];
   } //(^|[^\\$])\$(?!\$) //(?:^|[^\\\\\\])\\\$ //[^\\\\]\\\$
-  if (delimiters == "(") {
-    return ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3];
-  }
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
 }
 
@@ -926,9 +923,6 @@ function getNumDelimiters(delimiters) {
   }
   if (delimiters == "2") {
     return "$";
-  }
-  if (delimiters == "3") {
-    return "(";
   }
   return "$$";
 }

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -4,15 +4,13 @@
     <base target="_top">
     <meta charset="utf-8">
     <title>Auto-Latex Equations</title>
-    <!-- Google Analytics -->
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R3YH8795TS"></script>
     <script>
-//    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-//    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-//    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-//    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-//    
-//    ga('create', 'UA-XXXXX-Y', 'auto');
-//    ga('send', 'pageview');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R3YH8795TS');
     </script>
     <!-- End Google Analytics -->
 

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -60,6 +60,7 @@
           <select id = "delimit" name = "delimit">
             <option value = '$$' selected>$$ ... $$</option> <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value = '\['>\[ ... \]</option>
+            <option value = '('>\( ... \)</option>
             <!--<option value = '$'>$ ... $</option>-->
           </select>
         </div>

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -60,7 +60,6 @@
           <select id = "delimit" name = "delimit">
             <option value = '$$' selected>$$ ... $$</option> <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value = '\['>\[ ... \]</option>
-            <option value = '('>\( ... \)</option>
             <!--<option value = '$'>$ ... $</option>-->
           </select>
         </div>

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -46,6 +46,12 @@ const enum SlidesEquationRenderStatus {
   ClientRender,
   NoPresentation,
   Success,
+  // REASON: Distinguish UrlFetchApp authorization errors from generic renderer failure
+  // so the sidebar can show a "reinstall and click Select all" message instead of the
+  // misleading "an equation is incorrect" copy. Must be appended; const enum order is
+  // load-bearing because SlidesClientRenderStatus in Sidebar.ts must produce the same
+  // numeric values when both files are compiled independently.
+  AuthorizationFailed,
 }
 
 interface SlidesEquationRenderResult {
@@ -817,8 +823,11 @@ function placeImage(slideNum: number, textElement: PageElement, text: GoogleApps
     return [renderOptions.defaultSize, 1];
   }
 
-  const { renderer, rendererType, worked } = Common.renderEquation(equationOriginal, renderOptions); 
-  if (worked > Common.capableRenderers) return -100000;
+  const { renderer, rendererType, worked, authorizationError } = Common.renderEquation(equationOriginal, renderOptions);
+  // REASON: -100001 marks an auth-permission failure so callers (clientRenderFailed) can
+  // surface a "reinstall and grant external_request" message instead of treating it as a
+  // generic renderer-down error. -100000 stays the generic-failure sentinel.
+  if (worked > Common.capableRenderers) return authorizationError ? -100001 : -100000;
   var doc = IntegratedApp.getBody();
   var body = doc[slideNum];
 
@@ -1005,6 +1014,7 @@ function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEqu
  */
 function clientRenderFailed(equations: { options: SlidesClientRenderOptions }[]): SlidesEquationRenderResult {
   let successCount = 0;
+  let authorizationFailure = false;
 
   for (const equation of equations) {
     try {
@@ -1035,6 +1045,10 @@ function clientRenderFailed(equations: { options: SlidesClientRenderOptions }[])
 
       if (Array.isArray(result) && result[1] === 1) {
         successCount++;
+      } else if (result === -100001) {
+        // REASON: placeImage signals UrlFetchApp auth failure with -100001 so we can
+        // distinguish it from a generic renderer outage for the sidebar's error copy.
+        authorizationFailure = true;
       }
     } catch (error) {
       console.error("Slides server fallback render failed.", error);
@@ -1042,7 +1056,11 @@ function clientRenderFailed(equations: { options: SlidesClientRenderOptions }[])
   }
 
   return {
-    lastStatus: successCount > 0 ? SlidesEquationRenderStatus.Success : SlidesEquationRenderStatus.AllRenderersFailed,
+    lastStatus: successCount > 0
+      ? SlidesEquationRenderStatus.Success
+      : authorizationFailure
+        ? SlidesEquationRenderStatus.AuthorizationFailed
+        : SlidesEquationRenderStatus.AllRenderersFailed,
     successCount
   };
 }

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -19,6 +19,41 @@ interface DerenderData {
   height: number
 }
 
+interface SlidesClientRenderOptions {
+  size: number;
+  inline: boolean;
+  r: number;
+  g: number;
+  b: number;
+  delim: AutoLatexCommon.Delimiter;
+  equation: string;
+  equationLinkEncoded: string;
+  slideId: string;
+  pageElementId: string;
+  tableRow?: number;
+  tableColumn?: number;
+  rangeStart: number;
+  rangeEnd: number;
+}
+
+interface SlidesClientRenderPayload {
+  options: SlidesClientRenderOptions;
+  renderedEquationB64: string;
+}
+
+const enum SlidesEquationRenderStatus {
+  AllRenderersFailed,
+  ClientRender,
+  NoPresentation,
+  Success,
+}
+
+interface SlidesEquationRenderResult {
+  lastStatus: SlidesEquationRenderStatus;
+  successCount: number;
+  clientEquations?: SlidesClientRenderOptions[];
+}
+
 const IntegratedApp = {
   getUi: function () {
     return SlidesApp.getUi();
@@ -107,6 +142,9 @@ function isTableCell(element: PageElement): element is GoogleAppsScript.Slides.T
  */
 function replaceEquations(sizeRaw: string, delimiter: string, renderer: string = "auto") {
   const quality = 900;
+  const clientRender = renderer === "mathjax";
+  // REASON: In auto mode, try Codecogs server-side first, then MathJax on client, then Texrendr/Sciweavers.
+  const autoFallback = renderer === "auto";
   let size = Common.getSize(sizeRaw);
   let isInline = false;
   if (size < 0) {
@@ -119,7 +157,7 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
   let c = 0; //counter
   const defaultSize = 11;
   Common.reportDeltaTime(146);
-  
+
   // base render options common to all equations rendered
   const renderOptions: AutoLatexCommon.RenderOptions = {
     r: 0, g: 0, b: 0,
@@ -127,17 +165,71 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     defaultSize,
     size,
     inline: isInline,
-    // not yet supported for Slides
-    clientRender: false
+    clientRender
   };
-  
+
   // this can error if there are ungranted permissions
   try {
     IntegratedApp.getActive();
   } catch (error) {
     console.error(error);
+    if (clientRender || autoFallback) {
+      return {
+        lastStatus: SlidesEquationRenderStatus.NoPresentation,
+        successCount: 0
+      };
+    }
     return Common.encodeFlag(-1, 0);
   }
+
+  if (clientRender) {
+    const clientEquation = findClientRenderEquation(renderOptions);
+    if (!clientEquation) {
+      return {
+        lastStatus: SlidesEquationRenderStatus.Success,
+        successCount: 0
+      };
+    }
+    return {
+      lastStatus: SlidesEquationRenderStatus.ClientRender,
+      successCount: 0,
+      clientEquations: [clientEquation]
+    };
+  }
+
+  // REASON: Auto mode batches Codecogs first (fast, parallelized), then sends ALL
+  // remaining equations to the client for MathJax rendering in parallel.
+  if (autoFallback) {
+    // Phase 1: Batch render all equations with Codecogs only
+    const slides = IntegratedApp.getBody();
+    const childCount = slides.length;
+    for (let slideNum = 0; slideNum < childCount; slideNum++) {
+      const elements = slides[slideNum].getPageElements();
+      for (const element of elements) {
+        const castedElement = castElement(element);
+        if (castedElement === null) continue;
+        c += renderElement(slideNum, castedElement, {
+          ...renderOptions,
+          allowedServerFamilies: ["Codecogs"]
+        });
+      }
+    }
+
+    // Phase 2: Find ALL remaining equations (failed Codecogs) and send to client for parallel MathJax
+    const remainingEquations = findAllClientRenderEquations(renderOptions);
+    if (remainingEquations.length === 0) {
+      return {
+        lastStatus: SlidesEquationRenderStatus.Success,
+        successCount: c
+      };
+    }
+    return {
+      lastStatus: SlidesEquationRenderStatus.ClientRender,
+      successCount: c,
+      clientEquations: remainingEquations
+    };
+  }
+
   const slides = IntegratedApp.getBody();
   const childCount = slides.length;
   for (let slideNum = 0; slideNum < childCount; slideNum++) {
@@ -147,11 +239,129 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
       const castedElement = castElement(element);
       // if we don't recognize this element
       if (castedElement === null) continue;
-      
+
       c += renderElement(slideNum, castedElement, renderOptions);
     }
   }
   return Common.encodeFlag(0, c);
+}
+
+function findClientRenderEquation(renderOptions: AutoLatexCommon.RenderOptions): SlidesClientRenderOptions | null {
+  const slides = IntegratedApp.getBody();
+  for (let slideNum = 0; slideNum < slides.length; slideNum++) {
+    const slide = slides[slideNum];
+    for (const element of slide.getPageElements()) {
+      const castedElement = castElement(element);
+      if (!castedElement) {
+        continue;
+      }
+      const clientEquation = findClientRenderEquationInElement(slideNum, slide, castedElement, renderOptions);
+      if (clientEquation) {
+        return clientEquation;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Find ALL equations in the presentation that need client-side rendering.
+ * Unlike findClientRenderEquation which returns the first one, this collects all of them
+ * for batch processing (parallel MathJax rendering).
+ */
+function findAllClientRenderEquations(renderOptions: AutoLatexCommon.RenderOptions): SlidesClientRenderOptions[] {
+  const results: SlidesClientRenderOptions[] = [];
+  const slides = IntegratedApp.getBody();
+  for (let slideNum = 0; slideNum < slides.length; slideNum++) {
+    const slide = slides[slideNum];
+    for (const element of slide.getPageElements()) {
+      const castedElement = castElement(element);
+      if (!castedElement) continue;
+      findAllClientRenderEquationsInElement(slideNum, slide, castedElement, renderOptions, results);
+    }
+  }
+  return results;
+}
+
+function findAllClientRenderEquationsInElement(
+  slideNum: number,
+  slide: GoogleAppsScript.Slides.Slide,
+  element: GoogleAppsScript.Slides.Group | GoogleAppsScript.Slides.Table | GoogleAppsScript.Slides.Shape,
+  renderOptions: AutoLatexCommon.RenderOptions,
+  results: SlidesClientRenderOptions[]
+) {
+  if ("ungroup" in element) {
+    for (const childElement of element.getChildren()) {
+      const castedPageElement = castElement(childElement);
+      if (!castedPageElement) continue;
+      findAllClientRenderEquationsInElement(slideNum, slide, castedPageElement, renderOptions, results);
+    }
+    return;
+  }
+
+  if (isTable(element)) {
+    for (let row = 0; row < element.getNumRows(); row++) {
+      for (let column = 0; column < element.getNumColumns(); column++) {
+        const cell = element.getCell(row, column);
+        if (cell.getMergeState() === SlidesApp.CellMergeState.MERGED) continue;
+        findAllClientRenderEquationsInTextElement(slideNum, slide, cell, renderOptions, results);
+      }
+    }
+    return;
+  }
+
+  findAllClientRenderEquationsInTextElement(slideNum, slide, element, renderOptions, results);
+}
+
+function findAllClientRenderEquationsInTextElement(
+  slideNum: number,
+  slide: GoogleAppsScript.Slides.Slide,
+  textElement: PageElement,
+  renderOptions: AutoLatexCommon.RenderOptions,
+  results: SlidesClientRenderOptions[]
+) {
+  const textRange = unwrapEQ(textElement);
+  if (!textRange) return;
+
+  const renderedText = textRange.asRenderedString();
+  let searchOffset = 0;
+
+  while (searchOffset < renderedText.length) {
+    const equationOffsets = findNextEquationOffsetsInSlide(renderedText, renderOptions.delim, searchOffset);
+    if (!equationOffsets) break;
+
+    const endOffset = Math.min(textRange.getLength(), equationOffsets.end + renderOptions.delim[4]);
+    const equationRange = textRange.getRange(equationOffsets.start, endOffset);
+    const equationOriginal = getEquation(equationRange, renderOptions.delim);
+    if (!equationOriginal) {
+      searchOffset = equationOffsets.end + renderOptions.delim[4];
+      continue;
+    }
+
+    const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
+    const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
+    const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
+
+    results.push({
+      size,
+      inline: renderOptions.inline,
+      r: textColor[0],
+      g: textColor[1],
+      b: textColor[2],
+      delim: renderOptions.delim,
+      equation: clientEquation,
+      equationLinkEncoded: encodeURIComponent(clientEquation),
+      slideId: slide.getObjectId(),
+      pageElementId: getTargetObjectId(textElement),
+      tableRow: isTableCell(textElement) ? textElement.getRowIndex() : undefined,
+      tableColumn: isTableCell(textElement) ? textElement.getColumnIndex() : undefined,
+      rangeStart: equationOffsets.start,
+      rangeEnd: endOffset
+    });
+
+    searchOffset = equationOffsets.end + renderOptions.delim[4];
+  }
 }
 
 function castElement(element: GoogleAppsScript.Slides.PageElement) {
@@ -174,6 +384,45 @@ function castElement(element: GoogleAppsScript.Slides.PageElement) {
     return element.asGroup();
   }
   return null;
+}
+
+function findClientRenderEquationInElement(
+  slideNum: number,
+  slide: GoogleAppsScript.Slides.Slide,
+  element: GoogleAppsScript.Slides.Group | GoogleAppsScript.Slides.Table | GoogleAppsScript.Slides.Shape,
+  renderOptions: AutoLatexCommon.RenderOptions
+) {
+  if ("ungroup" in element) {
+    for (const childElement of element.getChildren()) {
+      const castedPageElement = castElement(childElement);
+      if (!castedPageElement) {
+        continue;
+      }
+      const clientEquation = findClientRenderEquationInElement(slideNum, slide, castedPageElement, renderOptions);
+      if (clientEquation) {
+        return clientEquation;
+      }
+    }
+    return null;
+  }
+
+  if (isTable(element)) {
+    for (let row = 0; row < element.getNumRows(); row++) {
+      for (let column = 0; column < element.getNumColumns(); column++) {
+        const cell = element.getCell(row, column);
+        if (cell.getMergeState() === SlidesApp.CellMergeState.MERGED) {
+          continue;
+        }
+        const clientEquation = findClientRenderEquationInTextElement(slideNum, slide, cell, renderOptions);
+        if (clientEquation) {
+          return clientEquation;
+        }
+      }
+    }
+    return null;
+  }
+
+  return findClientRenderEquationInTextElement(slideNum, slide, element, renderOptions);
 }
 
 /**
@@ -212,6 +461,51 @@ function renderElement(slideNum: number, element: GoogleAppsScript.Slides.Group 
     let parsedEquations = findPos(slideNum, element, renderOptions); //or: "\\\$\\\$", "\\\$\\\$"
     return parsedEquations.filter(([, imagesPlaced]) => imagesPlaced).length;
   }
+}
+
+function isEscapedSingleDollarInSlide(text: string, offset: number) {
+  let slashCount = 0;
+  for (let index = offset - 1; index >= 0 && text.charAt(index) === "\\"; index--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+function findNextSingleDollarInSlide(text: string, offset = 0) {
+  let candidate = text.indexOf("$", offset);
+  while (candidate !== -1) {
+    if (
+      !isEscapedSingleDollarInSlide(text, candidate) &&
+      (candidate === 0 || text.charAt(candidate - 1) !== "$") &&
+      (candidate + 1 >= text.length || text.charAt(candidate + 1) !== "$")
+    ) {
+      return candidate;
+    }
+    candidate = text.indexOf("$", candidate + 1);
+  }
+  return -1;
+}
+
+function findNextDelimiterOffsetInSlide(text: string, delimiters: AutoLatexCommon.Delimiter, offset = 0, useEndDelimiter = false) {
+  if (delimiters[6] === 2) {
+    return findNextSingleDollarInSlide(text, offset);
+  }
+  return text.indexOf(useEndDelimiter ? delimiters[1] : delimiters[0], offset);
+}
+
+function findNextEquationOffsetsInSlide(text: string, delimiters: AutoLatexCommon.Delimiter, offset = 0) {
+  const placeHolderStart = findNextDelimiterOffsetInSlide(text, delimiters, offset);
+  if (placeHolderStart === -1) {
+    return null;
+  }
+  const placeHolderEnd = findNextDelimiterOffsetInSlide(text, delimiters, placeHolderStart + delimiters[4], true);
+  if (placeHolderEnd === -1) {
+    return null;
+  }
+  return {
+    start: placeHolderStart,
+    end: placeHolderEnd
+  };
 }
 
 // slideNum and slideObjectNum are integers
@@ -271,6 +565,9 @@ function findPos(slideNum: number, element: PageElement, renderOptions: AutoLate
   if (!element)
     imagesPlaced.push([0, 0]);
   else {
+    // REASON: Track search offset so that when a renderer fails (text unchanged),
+    // we skip past the failed equation instead of re-finding it in an infinite loop.
+    let searchOffset = 0;
     for (let i = 0; i < 100; i++) { // Parse a maximum of 100 equations per TextRange
       // Get the text of the shape.
       // var elementText = shape.getText(); // TextRange
@@ -279,26 +576,14 @@ function findPos(slideNum: number, element: PageElement, renderOptions: AutoLate
         imagesPlaced.push([0, 0]);
         continue;
       }
-      // debugLog("Looking for delimiter :" + delim[2] + " in text");
-      const checkForDelimiter = elementText.find(renderOptions.delim[2]); // TextRange[]
-
-      if (checkForDelimiter == null) {
+      const equationOffsets = findNextEquationOffsetsInSlide(elementText.asRenderedString(), renderOptions.delim, searchOffset);
+      if (!equationOffsets) {
         imagesPlaced.push([0, 0]); // didn't find first delimiter
         break;
       }
 
-      // start position of image
-      const placeHolderStart = findTextOffsetInSlide(elementText.asRenderedString(), renderOptions.delim[0], 0);
-
-      if (placeHolderStart === -1) {
-        imagesPlaced.push([0, 0]); // didn't find first delimiter
-        break;
-      }
-
-      const offset = 2 + placeHolderStart;
-
-      // end position till of image
-      const placeHolderEnd = findTextOffsetInSlide(elementText.asRenderedString(), renderOptions.delim[1], offset);
+      const placeHolderStart = equationOffsets.start;
+      const placeHolderEnd = equationOffsets.end;
 
       Common.debugLog("Start and End of equation: " + placeHolderStart + " " + placeHolderEnd);
       // debugLog("Isolating Equation Textrange: " + element.getText().getRange(placeHolderStart, placeHolderEnd).asRenderedString());
@@ -306,7 +591,7 @@ function findPos(slideNum: number, element: PageElement, renderOptions: AutoLate
       const textColor = getRgbColor(element.getText().getRange(placeHolderStart + 1, placeHolderEnd), slideNum);
 
       Common.debugLog(`RGB: ${textColor.join()}`);
-      
+
       // include the ending delimiter as well
       const endOffset = Math.min(elementText.getLength(), placeHolderEnd + renderOptions.delim[4]);
       const equationRange = elementText.getRange(placeHolderStart, endOffset);
@@ -316,19 +601,103 @@ function findPos(slideNum: number, element: PageElement, renderOptions: AutoLate
         Common.debugLog("Empty equation!");
         equationRange.clear();
         imagesPlaced.push([renderOptions.defaultSize, 0]); // default behavior of placeImage
+        // REASON: Text was modified (cleared), reset offset to search from beginning.
+        searchOffset = 0;
         continue;
       }
 
-      imagesPlaced.push(placeImage(slideNum, element, equationRange, {
+      const result = placeImage(slideNum, element, equationRange, {
         // add color to renderOptions
         ...renderOptions,
         r: textColor[0],
         g: textColor[1],
         b: textColor[2]
-      }));
+      });
+      imagesPlaced.push(result);
+
+      if (result === -100000) {
+        // REASON: Rendering failed, text is unchanged. Advance past this equation
+        // to avoid finding it again on the next iteration.
+        searchOffset = placeHolderEnd + renderOptions.delim[4];
+      } else {
+        // REASON: Rendering succeeded, text was cleared and image was inserted.
+        // Reset offset since the text content changed.
+        searchOffset = 0;
+      }
     }
   }
   return imagesPlaced;
+}
+
+function getSlideTextSize(size: number, defaultSize: number, equationRange: GoogleAppsScript.Slides.TextRange) {
+  if (size !== 0) {
+    return size;
+  }
+  const textSize = equationRange.getTextStyle().getFontSize();
+  if (textSize === null || textSize <= 0) {
+    return defaultSize;
+  }
+  return textSize;
+}
+
+function getTargetObjectId(textElement: PageElement) {
+  return isTableCell(textElement)
+    ? textElement.getParentTable().getObjectId()
+    : textElement.getObjectId();
+}
+
+function findClientRenderEquationInTextElement(
+  slideNum: number,
+  slide: GoogleAppsScript.Slides.Slide,
+  textElement: PageElement,
+  renderOptions: AutoLatexCommon.RenderOptions
+) {
+  const textRange = unwrapEQ(textElement);
+  if (!textRange) {
+    return null;
+  }
+
+  const renderedText = textRange.asRenderedString();
+  let searchOffset = 0;
+
+  while (searchOffset < renderedText.length) {
+    const equationOffsets = findNextEquationOffsetsInSlide(renderedText, renderOptions.delim, searchOffset);
+    if (!equationOffsets) {
+      return null;
+    }
+
+    const endOffset = Math.min(textRange.getLength(), equationOffsets.end + renderOptions.delim[4]);
+    const equationRange = textRange.getRange(equationOffsets.start, endOffset);
+    const equationOriginal = getEquation(equationRange, renderOptions.delim);
+    if (!equationOriginal) {
+      searchOffset = equationOffsets.end + renderOptions.delim[4];
+      continue;
+    }
+
+    const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
+    const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
+    const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const clientEquation = decodeURIComponent(equationOriginal).replace(/\\\\/g, "\\");
+
+    return {
+      size,
+      inline: renderOptions.inline,
+      r: textColor[0],
+      g: textColor[1],
+      b: textColor[2],
+      delim: renderOptions.delim,
+      equation: clientEquation,
+      equationLinkEncoded: encodeURIComponent(clientEquation),
+      slideId: slide.getObjectId(),
+      pageElementId: getTargetObjectId(textElement),
+      tableRow: isTableCell(textElement) ? textElement.getRowIndex() : undefined,
+      tableColumn: isTableCell(textElement) ? textElement.getColumnIndex() : undefined,
+      rangeStart: equationOffsets.start,
+      rangeEnd: endOffset
+    };
+  }
+
+  return null;
 }
 
 function getEquation(textRange: GoogleAppsScript.Slides.TextRange, delimiters: AutoLatexCommon.Delimiter) {
@@ -504,6 +873,178 @@ function placeImage(slideNum: number, textElement: PageElement, text: GoogleApps
   }
   image.setTitle(JSON.stringify(derenderData));
   return [renderOptions.size, 1];
+}
+
+function findPageElementById(elements: GoogleAppsScript.Slides.PageElement[], pageElementId: string): GoogleAppsScript.Slides.PageElement | null {
+  for (const element of elements) {
+    if (element.getObjectId() === pageElementId) {
+      return element;
+    }
+    if (element.getPageElementType() === SlidesApp.PageElementType.GROUP) {
+      const groupMatch = findPageElementById(element.asGroup().getChildren(), pageElementId);
+      if (groupMatch) {
+        return groupMatch;
+      }
+    }
+  }
+  return null;
+}
+
+function resolveClientRenderTarget(options: SlidesClientRenderOptions) {
+  const slide = IntegratedApp.getBody().find(currentSlide => currentSlide.getObjectId() === options.slideId);
+  if (!slide) {
+    return null;
+  }
+
+  const pageElement = findPageElementById(slide.getPageElements(), options.pageElementId);
+  if (!pageElement) {
+    return null;
+  }
+
+  if (options.tableRow != null && options.tableColumn != null) {
+    if (pageElement.getPageElementType() !== SlidesApp.PageElementType.TABLE) {
+      return null;
+    }
+    const tableCell = pageElement.asTable().getCell(options.tableRow, options.tableColumn);
+    return {
+      slide,
+      textElement: tableCell,
+      textRange: tableCell.getText()
+    };
+  }
+
+  if (pageElement.getPageElementType() !== SlidesApp.PageElementType.SHAPE) {
+    return null;
+  }
+
+  const shape = pageElement.asShape();
+  return {
+    slide,
+    textElement: shape,
+    textRange: shape.getText()
+  };
+}
+
+function placeClientRenderedImage(
+  slide: GoogleAppsScript.Slides.Slide,
+  textElement: PageElement,
+  text: GoogleAppsScript.Slides.TextRange,
+  renderOptions: SlidesClientRenderOptions,
+  renderedEquation: GoogleAppsScript.Base.Blob
+) {
+  const equationRange = text.getRange(1, text.getLength());
+  const textHorizontalAlignment = equationRange
+    .getParagraphs()[0]
+    .getRange()
+    .getParagraphStyle()
+    .getParagraphAlignment();
+  const textVerticalAlignment = textElement.getContentAlignment();
+  const bounds = getBounds(textElement);
+  const mathJaxRenderer = Common.getRenderer(Common.rendererIds.MATHJAX);
+  const derenderData: DerenderData = {
+    red: renderOptions.r,
+    green: renderOptions.g,
+    blue: renderOptions.b,
+    origURL: mathJaxRenderer[2] + renderOptions.equationLinkEncoded + "#" + renderOptions.delim[6],
+    size: renderOptions.size,
+    width: bounds.width,
+    height: bounds.height
+  };
+
+  text.clear();
+
+  const image = slide.insertImage(renderedEquation);
+  resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds);
+
+  if (
+    !isTableCell(textElement) &&
+    textElement.getShapeType() === SlidesApp.ShapeType.TEXT_BOX &&
+    textElement.getText().asRenderedString().length <= 1
+  ) {
+    textElement.remove();
+  }
+
+  image.setTitle(JSON.stringify(derenderData));
+}
+
+function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEquationRenderResult {
+  let successCount = 0;
+
+  for (const equation of equations) {
+    try {
+      const target = resolveClientRenderTarget(equation.options);
+      if (!target) {
+        console.warn("MathJax Slides target disappeared before completion:", equation.options.pageElementId);
+        continue;
+      }
+
+      const safeEnd = Math.min(target.textRange.getLength(), equation.options.rangeEnd);
+      if (equation.options.rangeStart >= safeEnd) {
+        continue;
+      }
+
+      const equationRange = target.textRange.getRange(equation.options.rangeStart, safeEnd);
+      const equationBlob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
+      placeClientRenderedImage(target.slide, target.textElement, equationRange, equation.options, equationBlob);
+      successCount++;
+    } catch (error) {
+      console.error("MathJax Slides client render completion failed.", error);
+    }
+  }
+
+  return {
+    lastStatus: successCount > 0 ? SlidesEquationRenderStatus.Success : SlidesEquationRenderStatus.AllRenderersFailed,
+    successCount
+  };
+}
+
+/**
+ * Called by the client when MathJax rendering fails in auto mode.
+ * Tries remaining server-side renderers (Texrendr, Sciweavers) for the failed equations.
+ * @public
+ */
+function clientRenderFailed(equations: { options: SlidesClientRenderOptions }[]): SlidesEquationRenderResult {
+  let successCount = 0;
+
+  for (const equation of equations) {
+    try {
+      const target = resolveClientRenderTarget(equation.options);
+      if (!target) {
+        console.warn("Slides server fallback: target disappeared:", equation.options.pageElementId);
+        continue;
+      }
+
+      const safeEnd = Math.min(target.textRange.getLength(), equation.options.rangeEnd);
+      if (equation.options.rangeStart >= safeEnd) continue;
+
+      const equationRange = target.textRange.getRange(equation.options.rangeStart, safeEnd);
+      const slideNum = IntegratedApp.getBody().findIndex(s => s.getObjectId() === equation.options.slideId);
+
+      // REASON: Try Texrendr and Sciweavers only - Codecogs already failed, MathJax already failed.
+      const result = placeImage(slideNum, target.textElement, equationRange, {
+        size: equation.options.size,
+        defaultSize: equation.options.size,
+        inline: equation.options.inline,
+        delim: equation.options.delim,
+        clientRender: false,
+        r: equation.options.r,
+        g: equation.options.g,
+        b: equation.options.b,
+        allowedServerFamilies: ["Texrendr", "Sciweavers", "Sciweavers_old", "Roger's renderer", "Number empire"]
+      });
+
+      if (Array.isArray(result) && result[1] === 1) {
+        successCount++;
+      }
+    } catch (error) {
+      console.error("Slides server fallback render failed.", error);
+    }
+  }
+
+  return {
+    lastStatus: successCount > 0 ? SlidesEquationRenderStatus.Success : SlidesEquationRenderStatus.AllRenderersFailed,
+    successCount
+  };
 }
 
 /**

--- a/Slides/Sidebar.html
+++ b/Slides/Sidebar.html
@@ -69,12 +69,14 @@
             <option value="$$" selected>$$ ... $$</option>
             <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value="\[">\[ ... \]</option>
-            <!--<option value = '$'>$ ... $</option>-->
+            <option value="(">\( ... \)</option>
+            <option value="$">$ ... $</option>
           </select>
           <label id="select_size">Preferred Renderer:<br /></label>
-          <select id="renderer" name="renderer">
+          <select id="renderer" name="renderer" data-mathjax-enabled="true">
             <option value="auto" selected>Automatic</option>
             <option value="codecogs">Codecogs</option>
+            <option value="mathjax">MathJax beta</option>
             <option value="texrendr">Texrendr</option>
             <option value="sciweavers">Sciweavers</option>
           </select>

--- a/Slides/Sidebar.html
+++ b/Slides/Sidebar.html
@@ -4,15 +4,13 @@
     <base target="_top" />
     <meta charset="utf-8" />
     <title>Auto-Latex Equations</title>
-    <!-- Google Analytics -->
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R3YH8795TS"></script>
     <script>
-      //    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      //    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      //    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      //    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      //
-      //    ga('create', 'UA-XXXXX-Y', 'auto');
-      //    ga('send', 'pageview');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R3YH8795TS');
     </script>
     <!-- End Google Analytics -->
 
@@ -72,6 +70,7 @@
             <option value="(">\( ... \)</option>
             <option value="$">$ ... $</option>
           </select>
+          <br />
           <label id="select_size">Preferred Renderer:<br /></label>
           <select id="renderer" name="renderer" data-mathjax-enabled="true">
             <option value="auto" selected>Automatic</option>

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -44,6 +44,10 @@ const enum SlidesClientRenderStatus {
   ClientRender,
   NoPresentation,
   Success,
+  // REASON: Must mirror Code.ts SlidesEquationRenderStatus exactly. const enums get
+  // inlined as numbers per file at compile time, so the order here has to match the
+  // server-side definition or values arriving via google.script.run will be misread.
+  AuthorizationFailed,
 }
 
 function isSlidesEquationRenderResult(value: unknown): value is SlidesClientEquationRenderResult {
@@ -291,6 +295,8 @@ function insertText(){
     const statusText = makeSlidesRenderStatusText(mathJaxRenderedCount);
     if (result.lastStatus === SlidesClientRenderStatus.NoPresentation)
       showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", statusText);
+    else if (result.lastStatus === SlidesClientRenderStatus.AuthorizationFailed)
+      showError("<strong>Auto-LaTeX is missing permission to call external renderers.</strong> Try uninstalling and reinstalling the add-on, then click 'Select all' on the permissions screen. The equation may be valid; Google has not granted the add-on external request access yet.", statusText);
     else if (result.lastStatus === SlidesClientRenderStatus.AllRenderersFailed && mathJaxRenderedCount > 0)
       showError("Sorry, the equation is too long or another problem occurred.", statusText);
     else if (result.lastStatus === SlidesClientRenderStatus.AllRenderersFailed && mathJaxRenderedCount === 0)

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -5,6 +5,156 @@
 /// <reference path="../types/common-types/index.d.ts" />
 /// <reference lib="dom" />
 
+interface MathJaxApi {
+  tex2svgPromise(equation: string, options: { display: boolean, em: number }): Promise<Element>;
+  svgStylesheet(): Element;
+}
+
+interface Window {
+  MathJax: MathJaxApi;
+}
+
+declare const MathJax: MathJaxApi;
+
+interface SlidesClientRenderOptions {
+  size: number;
+  inline: boolean;
+  r: number;
+  g: number;
+  b: number;
+  delim: AutoLatexCommon.Delimiter;
+  equation: string;
+  equationLinkEncoded: string;
+  slideId: string;
+  pageElementId: string;
+  tableRow?: number;
+  tableColumn?: number;
+  rangeStart: number;
+  rangeEnd: number;
+}
+
+interface SlidesClientEquationRenderResult {
+  lastStatus: SlidesClientRenderStatus;
+  successCount: number;
+  clientEquations?: SlidesClientRenderOptions[];
+}
+
+const enum SlidesClientRenderStatus {
+  AllRenderersFailed,
+  ClientRender,
+  NoPresentation,
+  Success,
+}
+
+function isSlidesEquationRenderResult(value: unknown): value is SlidesClientEquationRenderResult {
+  return typeof value === "object" && value !== null && "lastStatus" in value;
+}
+
+function makeSlidesRenderStatusText(renderCount: number) {
+  if (renderCount == 0)
+    return "Status: No equations rendered";
+  else if (renderCount == 1)
+    return "Status: 1 equation rendered";
+  return `Status: ${renderCount} equations rendered`;
+}
+
+// REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in parallel
+// (e.g. 1000 equations) would freeze the browser. This limits concurrency to a safe number.
+const MATHJAX_CONCURRENCY_LIMIT = 4;
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+async function blobToB64(blob: Blob) {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = err => reject(err);
+    reader.readAsDataURL(blob);
+  });
+  return dataUrl.substring(dataUrl.indexOf(",") + 1);
+}
+
+async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + renderOptions.equation.replace(/\n|\r|\r\n/g, "\\\\");
+
+  if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
+    throw new Error("MathJax is still loading. Please try again in a moment.");
+  }
+
+  const result = await window.MathJax.tex2svgPromise(equation, {
+    display: !renderOptions.inline,
+    em: renderOptions.size
+  });
+  const svg: SVGSVGElement | null = result.querySelector("svg");
+  if (!svg) {
+    throw new Error("MathJax did not return an SVG element.");
+  }
+
+  svg.classList.add("mathjax-equation-hidden-render");
+  svg.style.fontSize = `${renderOptions.size}px`;
+  document.body.appendChild(svg);
+
+  const width = svg.clientWidth * 5;
+  const height = svg.clientHeight * 5;
+
+  svg.remove();
+  svg.setAttribute("width", `${width}px`);
+  svg.setAttribute("height", `${height}px`);
+
+  const styles = MathJax.svgStylesheet().outerHTML;
+  const svgString = new XMLSerializer().serializeToString(svg).replace("</svg>", styles + "</svg>");
+  const svgBlob = new Blob([svgString], {
+    type: "image/svg+xml"
+  });
+  const svgUrl = URL.createObjectURL(svgBlob);
+
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Could not initialize a 2D canvas for MathJax rendering.");
+  }
+
+  try {
+    const svgImage = new Image(width, height);
+    svgImage.src = svgUrl;
+    await new Promise<void>((resolve, reject) => {
+      svgImage.onload = () => resolve();
+      svgImage.onerror = err => reject(err);
+    });
+
+    ctx.drawImage(svgImage, 0, 0);
+
+    return "convertToBlob" in canvas
+      ? await canvas.convertToBlob({ type: "image/png" })
+      : await new Promise<Blob>((resolve, reject) => {
+          (canvas as HTMLCanvasElement).toBlob(blob => {
+            if (blob) {
+              resolve(blob);
+            } else {
+              reject(new Error("Could not convert MathJax canvas to a PNG blob."));
+            }
+          }, "image/png");
+        });
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
+}
+
 /**
  * On document load, assign click handlers to each button. Added document.ready.
  */
@@ -84,7 +234,7 @@ function loadPreferences(choicePrefs: {size: string, delim: string, renderer: st
     $('#custom-size').hide();
   }
   $('#delimit').val(choicePrefs.delim);
-  const savedRenderer = ["auto", "codecogs", "texrendr", "sciweavers"].includes(choicePrefs.renderer) ? choicePrefs.renderer : "auto";
+  const savedRenderer = ["auto", "codecogs", "mathjax", "texrendr", "sciweavers"].includes(choicePrefs.renderer) ? choicePrefs.renderer : "auto";
   $('#renderer').val(savedRenderer);
   $('#insert-text').prop("disabled", false);
   $('#edit-text').prop("disabled", false);
@@ -98,51 +248,138 @@ function insertText(){
   $("#loading").html("Status: Loading");
   const runDots = runDotAnimation();
   const {sizeRaw, delimiter, renderer} = getCurrentSettings();
+  let mathJaxRenderedCount = 0;
+
+  const finishNumericRender = function(returnSuccess: number, element: HTMLButtonElement) {
+    $("#loading").html('');
+    clearInterval(runDots);
+    element.disabled = false;
+    console.log(returnSuccess);
+    let flag = 0;
+    let renderCount = 1;
+    if(returnSuccess < -1){
+      flag = -2;
+      renderCount = -2 - returnSuccess;
+    }
+    else if(returnSuccess == -1){
+      flag = -1;
+      renderCount = 0;
+    }
+    else{
+      flag = 0;
+      renderCount = returnSuccess;
+    }
+    if(flag == -1)
+      showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", "Status: " + renderCount +  " equations replaced");
+    else if(flag == -2 && renderCount > 0)
+      showError("Sorry, the equation is too long or another problem occurred.", "Status: " + renderCount +  " equations replaced");
+    else if(flag == -2 && renderCount == 0)
+      showError("Sorry, the renderers are down, an equation is too long, or an equation is misformed.", "Status: " + renderCount +  " equations replaced");
+    else if(flag == 0 && renderCount == 0)
+      $("#loading").html("Status: " + "No"          + " equations rendered");
+    else if(flag == 0 && renderCount == 1)
+      $("#loading").html("Status: " + renderCount + " equation rendered" );
+    else
+      $("#loading").html("Status: " + renderCount + " equations rendered");
+  };
+
+  const finishMathJaxRender = function(result: SlidesClientEquationRenderResult, element: HTMLButtonElement) {
+    $("#loading").html('');
+    clearInterval(runDots);
+    element.disabled = false;
+
+    const statusText = makeSlidesRenderStatusText(mathJaxRenderedCount);
+    if (result.lastStatus === SlidesClientRenderStatus.NoPresentation)
+      showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", statusText);
+    else if (result.lastStatus === SlidesClientRenderStatus.AllRenderersFailed && mathJaxRenderedCount > 0)
+      showError("Sorry, the equation is too long or another problem occurred.", statusText);
+    else if (result.lastStatus === SlidesClientRenderStatus.AllRenderersFailed && mathJaxRenderedCount === 0)
+      showError("Sorry, the renderers are down, an equation is too long, or an equation is misformed.", statusText);
+    else
+      $("#loading").html(statusText);
+  };
+
+  const handleFailure = function(msg: unknown, element: HTMLButtonElement) {
+    $("#loading").html('');
+    clearInterval(runDots);
+    console.error("Error console errored!", msg, element);
+    showError("Please ensure your equations are surrounded by $$ on both sides (or \\[ and an \\]), without any enters in between, or reload the page.", "Status: Error, please reload.");
+    element.disabled = false;
+  };
+
+  const requestNextMathJaxBatch = function(element: HTMLButtonElement) {
+    google.script.run
+      .withSuccessHandler((response, userObject) => handleSuccess(response, userObject as HTMLButtonElement))
+      .withFailureHandler((msg, userObject) => handleFailure(msg, userObject as HTMLButtonElement))
+      .withUserObject(element)
+      .replaceEquations(sizeRaw, delimiter, renderer);
+  };
+
+  const handleMathJaxResponse = function(result: SlidesClientEquationRenderResult, element: HTMLButtonElement) {
+    if (result.lastStatus === SlidesClientRenderStatus.ClientRender) {
+      const equationsToRender = result.clientEquations || [];
+      if (equationsToRender.length === 0) {
+        finishMathJaxRender({
+          lastStatus: SlidesClientRenderStatus.AllRenderersFailed,
+          successCount: 0
+        }, element);
+        return;
+      }
+
+      // REASON: In auto mode, count any server-side successes (Codecogs) in the total.
+      mathJaxRenderedCount += result.successCount;
+
+      // REASON: Render ALL equations with concurrency limit to avoid freezing the browser.
+      mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, eq =>
+        renderMathJaxEquation(eq)
+          .then(blob => blobToB64(blob))
+          .then(b64 => ({ options: eq, renderedEquationB64: b64 }))
+      )
+        .then(rendered => {
+          const scriptRun = google.script.run as any;
+          scriptRun
+            .withSuccessHandler((response: SlidesClientEquationRenderResult, userObject: HTMLButtonElement) => handleMathJaxResponse(response, userObject))
+            .withFailureHandler((msg: unknown, userObject: HTMLButtonElement) => handleFailure(msg, userObject))
+            .withUserObject(element)
+            .clientRenderComplete(rendered);
+        })
+        .catch(error => {
+          // REASON: In auto mode, if MathJax fails, try remaining server renderers (Texrendr/Sciweavers)
+          if (renderer === "auto") {
+            const scriptRun = google.script.run as any;
+            scriptRun
+              .withSuccessHandler((response: SlidesClientEquationRenderResult, userObject: HTMLButtonElement) => handleMathJaxResponse(response, userObject))
+              .withFailureHandler((msg: unknown, userObject: HTMLButtonElement) => handleFailure(msg, userObject))
+              .withUserObject(element)
+              .clientRenderFailed(equationsToRender.map(eq => ({ options: eq })));
+          } else {
+            handleFailure(error, element);
+          }
+        });
+      return;
+    }
+
+    mathJaxRenderedCount += result.successCount;
+    if (result.lastStatus === SlidesClientRenderStatus.Success && result.successCount > 0) {
+      requestNextMathJaxBatch(element);
+      return;
+    }
+
+    finishMathJaxRender(result, element);
+  };
+
+  const handleSuccess = function(returnSuccess: number | SlidesClientEquationRenderResult, element: HTMLButtonElement) {
+    // REASON: In auto mode, server returns object responses (like MathJax mode) for the one-at-a-time flow.
+    if ((renderer === "mathjax" || renderer === "auto") && isSlidesEquationRenderResult(returnSuccess)) {
+      handleMathJaxResponse(returnSuccess, element);
+      return;
+    }
+    finishNumericRender(returnSuccess as number, element);
+  };
 
   google.script.run
-    .withSuccessHandler(
-      function(returnSuccess, element) {
-        $("#loading").html('');
-        clearInterval(runDots);
-        element.disabled = false;
-        console.log(returnSuccess);
-        let flag = 0;
-        let renderCount = 1;
-        if(returnSuccess < -1){
-          flag = -2;
-          renderCount = -2 - returnSuccess;
-        }
-        else if(returnSuccess == -1){
-          flag = -1;
-          renderCount = 0;
-        }
-        else{
-          flag = 0;
-          renderCount = returnSuccess;
-        }
-        // var flag = returnSuccess.flag
-        // var renderCount = returnSuccess.renderCount
-        if(flag == -1)
-          showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", "Status: " + renderCount +  " equations replaced");
-        else if(flag == -2 && renderCount > 0)
-          showError("Sorry, the equation is too long or another problem occurred.", "Status: " + renderCount +  " equations replaced");
-        else if(flag == -2 && renderCount == 0)
-          showError("Sorry, the renderers are down, an equation is too long, or an equation is misformed.", "Status: " + renderCount +  " equations replaced");
-        else if(flag == 0 && renderCount == 0)
-          $("#loading").html("Status: " + "No"          + " equations rendered");
-        else if(flag == 0 && renderCount == 1)
-          $("#loading").html("Status: " + renderCount + " equation rendered" );
-        else
-          $("#loading").html("Status: " + renderCount + " equations rendered");
-      })
-    .withFailureHandler(
-      function(msg, element) {
-        $("#loading").html('');
-        clearInterval(runDots);
-        console.error("Error console errored!", msg, element)
-        showError("Please ensure your equations are surrounded by $$ on both sides (or \\[ and an \\]), without any enters in between, or reload the page.", "Status: Error, please reload.");
-        element.disabled = false;
-    })
+    .withSuccessHandler((returnSuccess, element) => handleSuccess(returnSuccess, element as HTMLButtonElement))
+    .withFailureHandler((msg, element) => handleFailure(msg, element as HTMLButtonElement))
     .withUserObject(this)
     .replaceEquations(sizeRaw, delimiter, renderer);
 }

--- a/Slides/appsscript.json
+++ b/Slides/appsscript.json
@@ -1,13 +1,6 @@
 {
   "timeZone": "America/Los_Angeles",
   "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Analytics",
-        "serviceId": "analytics",
-        "version": "v3"
-      }
-    ],
     "libraries": [
       {
         "userSymbol": "Common",

--- a/Workspace/Code.ts
+++ b/Workspace/Code.ts
@@ -21,7 +21,9 @@ function generateWorkspaceHomepage(status: string, error: string | null = null) 
 
   const delims = [
     ["$$ ... $$", "$$"],
-    ["\\[ ... \\]", "\["]
+    ["\\[ ... \\]", "["],
+    ["\\( ... \\)", "("],
+    ["$ ... $", "$"]
   ];
   const renderers = [
     ["Automatic", "auto"],

--- a/Workspace/Docs.ts
+++ b/Workspace/Docs.ts
@@ -23,7 +23,8 @@ const DocsApp = {
 	getPageWidth: function() {
 		let activeWidth = DocumentApp.getActiveDocument().getBody().getPageWidth();
 		return activeWidth;
-	}
+	},
+	newlineCharacter: "%0D"
 };
 
 /**
@@ -132,7 +133,7 @@ function getEquation(paragraph: GoogleAppsScript.Document.Paragraph, childIndex:
     .getText()
     .substring(start + delimiters[4], end - delimiters[4] + 1);
     Common.debugLog("See equation", equation);
-    const equationStringEncoded = Common.reEncode(equation); //escape deprecated
+    const equationStringEncoded = Common.reEncode(equation, DocsApp); //escape deprecated
   equationOriginal.push(equationStringEncoded);
   Common.reportDeltaTime(290);
   //console.log("Encoded: " + equationStringEncoded);
@@ -332,7 +333,7 @@ function removeAll(defaultDelimRaw: string) {
       }
       // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
       // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-      const result = Common.derenderEquation(origURL);
+      const result = Common.derenderEquation(origURL, DocsApp);
       if (!result) continue;
       const { origEq, delim: newDelim } = result;
       const delim = newDelim || defaultDelim;
@@ -384,7 +385,7 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
         return Common.DerenderResult.NullUrl;
       }
       Common.debugLog("Original URL from image", origURL);
-      const result = Common.derenderEquation(origURL);
+      const result = Common.derenderEquation(origURL, DocsApp);
       if (!result) return Common.DerenderResult.InvalidUrl;
       const { delim: newDelim, origEq } = result;
       const delim = newDelim || defaultDelim;

--- a/Workspace/Sheets.ts
+++ b/Workspace/Sheets.ts
@@ -14,8 +14,38 @@ const SheetsApp = {
 	getPageWidth: function() {
 		let activeWidth = SpreadsheetApp.getActiveSheet().getMaxRows();
 		return activeWidth;
-	}
+	},
+	newlineCharacter: "%0A"
 };
+
+const SheetsIntegratedApp = SheetsApp as unknown as AutoLatexCommon.IntegratedApp;
+const SHEETS_INLINE_IMAGE_METADATA_KEY = "autolatex-inline-image";
+
+type SheetImage = GoogleAppsScript.Spreadsheet.OverGridImage | GoogleAppsScript.Spreadsheet.CellImage;
+type SheetImageAltText = [number, number, number, string];
+
+function buildSheetImageAltText(color: [number, number, number], origURL: string): string {
+  return JSON.stringify([...color, origURL]);
+}
+
+function parseSheetImageAltText(image: SheetImage): SheetImageAltText | null {
+  try {
+    const parsed = JSON.parse(image.getAltTextDescription());
+    if (!Array.isArray(parsed) || parsed.length < 4) return null;
+    const [red, green, blue, origURL] = parsed;
+    if (origURL === null || origURL === undefined || origURL === "") return null;
+    return [Number(red), Number(green), Number(blue), String(origURL)];
+  } catch (err) {
+    console.log("Could not parse Auto-LaTeX Sheets image alt text.");
+    return null;
+  }
+}
+
+function removeInlineImageMetadata(cell: GoogleAppsScript.Spreadsheet.Range) {
+  cell.getDeveloperMetadata()
+    .filter(metadata => metadata.getKey() === SHEETS_INLINE_IMAGE_METADATA_KEY)
+    .forEach(metadata => metadata.remove());
+}
 
 /**
  * Constantly keep replacing latex till all are finished
@@ -38,7 +68,10 @@ function replaceEquationsSheets(sizeRaw: string, delimiter: string, renderer: st
   
   for (let match = textFinder.findNext(); match !== null; match = textFinder.findNext()) {
     // Remove the delimiters
-    const [, equationOriginal] = (<string>match.getValue()).match(regex);
+    const matchValue = String(match.getValue());
+    const regexMatch = matchValue.match(regex);
+    if (!regexMatch) continue;
+    const [, equationOriginal] = regexMatch;
     if (equationOriginal === "") continue;
 
     // Get the color
@@ -48,10 +81,11 @@ function replaceEquationsSheets(sizeRaw: string, delimiter: string, renderer: st
       color = [rangeColor.getRed(), rangeColor.getGreen(), rangeColor.getBlue()];
     }
 
-    let { renderer, worked, rendererType, resp } = Common.renderEquation(Common.reEncode(equationOriginal), quality, delim, isInline, ...color);
-    if (worked > Common.capableRenderers) return Common.encodeFlag(-2, counter);
+    const equationEncoded = Common.reEncode(equationOriginal, SheetsIntegratedApp);
+    let { renderer, worked, rendererType, resp } = Common.renderEquation(equationEncoded, quality, delim, isInline, ...color);
+    if (worked > Common.capableRenderers || !renderer || !resp) return Common.encodeFlag(-2, counter);
 
-    const titleJson = JSON.stringify([...color, renderer[2] + equationOriginal + "#" + delim[6]]);
+    const titleJson = buildSheetImageAltText(color, renderer[2] + equationEncoded + "#" + delim[6]);
 
     if (isInline) {
       // An in-cell image. Resizes with the cell
@@ -63,7 +97,7 @@ function replaceEquationsSheets(sizeRaw: string, delimiter: string, renderer: st
       match.setValue(image);
 
       // This is so that we can easily find it when derendering everything
-      match.addDeveloperMetadata("autolatex-inline-image", GoogleAppsScript.Spreadsheet.DeveloperMetadataVisibility.PROJECT);
+      match.addDeveloperMetadata(SHEETS_INLINE_IMAGE_METADATA_KEY, GoogleAppsScript.Spreadsheet.DeveloperMetadataVisibility.PROJECT);
     } else {
       // An over-grid image
       const newSize = size || match.getFontSize();
@@ -77,7 +111,7 @@ function replaceEquationsSheets(sizeRaw: string, delimiter: string, renderer: st
         scale = (newSize / 200.0);
       else if (rendererType.valueOf() === "Sciweavers".valueOf())
         //Scieweavers
-        scale = (1 / 98.0);
+        scale = (newSize / 98.0);
       else if (rendererType.valueOf() === "Sciweavers_old".valueOf())
         //C [75.4, 79.6] on width and height ratio
         scale = (newSize / 76.0);
@@ -114,7 +148,10 @@ function resizeSheetImage(image: GoogleAppsScript.Spreadsheet.OverGridImage, sca
 }
 
 function isCellImage(value: any): value is GoogleAppsScript.Spreadsheet.CellImage {
-  return value.valueType === SpreadsheetApp.ValueType.IMAGE;
+  return value
+    && typeof value.getAltTextDescription === "function"
+    && typeof value.getContentUrl === "function"
+    && typeof value.toBuilder === "function";
 }
 
 /**
@@ -132,7 +169,9 @@ function derenderEquationSheets(sizeRaw: string, delimiter: string, renderer: st
   if (cell) {
     const val = cell.getValue();
     if (isCellImage(val)) {
-      return derenderSingleSheetImage(val, cell, defaultDelim);
+      const result = derenderSingleSheetImage(val, cell, defaultDelim);
+      if (result === Common.DerenderResult.Success) removeInlineImageMetadata(cell);
+      return result;
     } else {
       // Iterate over all of the OverGridImages on the sheet until we find the one
       const images = SheetsApp.getBody().getImages();
@@ -166,18 +205,36 @@ function derenderAllSheets(delimiter: string) {
     }
   });
 
-  // TODO: Derender cell images
+  SheetsApp.getActive().getSheets().forEach(sheet => {
+    const range = sheet.getDataRange();
+    const values = range.getValues();
+
+    values.forEach((row, rowOffset) => {
+      row.forEach((value, colOffset) => {
+        if (!isCellImage(value)) return;
+
+        const cell = range.offset(rowOffset, colOffset, 1, 1);
+        const result = derenderSingleSheetImage(value, cell, defaultDelim);
+        if (result === Common.DerenderResult.Success) {
+          removeInlineImageMetadata(cell);
+          successCount++;
+        }
+      });
+    });
+  });
 
   return successCount;
 }
 
 function derenderSingleSheetImage(image: GoogleAppsScript.Spreadsheet.OverGridImage | GoogleAppsScript.Spreadsheet.CellImage, cell: GoogleAppsScript.Spreadsheet.Range, defaultDelim: AutoLatexCommon.Delimiter) {
-  const [red, green, blue, origURL] = JSON.parse(image.getAltTextDescription());
-  const colors = [red, green, blue].map((x: string) => Number(x).toString(16).padStart(2, '0'));
+  const parsedAltText = parseSheetImageAltText(image);
+  if (!parsedAltText) return Common.DerenderResult.InvalidUrl;
+  const [red, green, blue, origURL] = parsedAltText;
+  const colors = [red, green, blue].map(x => Number(x).toString(16).padStart(2, '0'));
 
   if (!origURL) return Common.DerenderResult.NullUrl;
 
-  const result = Common.derenderEquation(origURL);
+  const result = Common.derenderEquation(origURL, SheetsIntegratedApp);
   if (!result) return Common.DerenderResult.InvalidUrl;
   const { delim: newDelim, origEq } = result;
   const delim = newDelim || defaultDelim;

--- a/Workspace/appsscript.json
+++ b/Workspace/appsscript.json
@@ -1,13 +1,6 @@
 {
   "timeZone": "America/Los_Angeles",
   "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Analytics",
-        "serviceId": "analytics",
-        "version": "v3"
-      }
-    ],
     "libraries": [
       {
         "userSymbol": "Common",
@@ -17,6 +10,16 @@
       }
     ]
   },
+  "urlFetchWhitelist": [
+    "https://latex.codecogs.com/png.latex",
+    "https://latex.codecogs.com/gif.latex",
+    "https://www.codecogs.com/eqnedit.php",
+    "https://latex-staging.easygenerator.com/gif.latex",
+    "https://latex-staging.easygenerator.com/eqneditor/editor.php",
+    "https://texrendr.com/cgi-bin/mathtex.cgi",
+    "https://www.texrendr.com/",
+    "https://saxarona.github.io/mathjax-viewer/"
+  ],
   "addOns": {
     "common": {
       "homepageTrigger": {

--- a/Workspace/package.json
+++ b/Workspace/package.json
@@ -4,8 +4,10 @@
   "description": "",
   "main": "Code.js",
   "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check-clasp-config": "test -f .clasp.json || (echo \"Missing Workspace/.clasp.json; refusing to push via parent clasp config\" >&2; exit 1)",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preclasp-push": "node ../BuildSidebarJS.js && node ../LibraryLinker.js link Workspace $npm_config_common_version",
+    "preclasp-push": "npm run build && npm run check-clasp-config && node ../LibraryLinker.js link Workspace $npm_config_common_version",
     "postclasp-push": "node ../LibraryLinker.js unlink Workspace",
     "clasp-push": "clasp push"
   },

--- a/Workspace/package.json
+++ b/Workspace/package.json
@@ -5,7 +5,7 @@
   "main": "Code.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preclasp-push": "node ../LibraryLinker.js link Workspace $npm_config_common_version",
+    "preclasp-push": "node ../BuildSidebarJS.js && node ../LibraryLinker.js link Workspace $npm_config_common_version",
     "postclasp-push": "node ../LibraryLinker.js unlink Workspace",
     "clasp-push": "clasp push"
   },

--- a/Workspace/tsconfig.json
+++ b/Workspace/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "typeRoots": ["../node_modules/@types"]
-  }
+    "typeRoots": ["../node_modules/@types", "../types"],
+    "types": ["google-apps-script", "common-types"],
+    "skipLibCheck": true
+  },
+  "files": ["Code.ts", "Docs.ts", "Sheets.ts"]
 }

--- a/autolatex_assets/code.js
+++ b/autolatex_assets/code.js
@@ -323,7 +323,6 @@ function getSize(sizeRaw){
 function getDelimiters(delimiters){// //HARDCODED DELIMTERS!!!!!!!!!!!!!
   if(delimiters=="$$"){return["$$", "$$", "\\\$\\\$", "\\\$\\\$"];}
   if(delimiters=="\["){return["\\[", "\\]", "\\\\\\[", "\\\\\\]"];}
-  if(delimiters=="("){return["\\(", "\\)", "\\\\\\(", "\\\\\\)"];}
   return ["\\[", "\\]", "\\\\\\[", "\\\\\\]"];
 }
 

--- a/skills/apps-script-push/SKILL.md
+++ b/skills/apps-script-push/SKILL.md
@@ -22,10 +22,13 @@ Do not hard-code production script IDs in this skill. If production IDs are need
 
 - `AUTOLATEX_PROD_COMMON_SCRIPT_ID`
 - `AUTOLATEX_PROD_DOCS_SCRIPT_ID`
+- `AUTOLATEX_PROD_SLIDES_SCRIPT_ID` — the live Slides Marketplace add-on; what `Slides/.clasp.json` points at by default.
+- `AUTOLATEX_PROD_SLIDES_VERSIONS_SCRIPT_ID` — separate Slides project where new prod versions are cut before the SDK App Config flips to them. Not the live add-on, but still production-adjacent.
+- `AUTOLATEX_TEST_SLIDES_SCRIPT_ID` — Slides sandbox for ad-hoc testing; safe to push freely.
 
 Do not push test or debugging changes to these production projects unless the user explicitly asks for a production push or restore. This is especially important for `Common`: some already-published Docs versions may reference `Common` with `version: "0"` and `developmentMode: true`, so pushing `Common` HEAD can immediately change production behavior without a new Docs version or Marketplace publish.
 
-For testing, use a separate Apps Script project or deployment, not production `Common` or production `Docs`. Before any push, print the target `.clasp.json` script ID and say whether it matches a production ID from `.env`, is a non-production target, or cannot be classified because `.env` is missing.
+For testing, use the Slides test sandbox (`AUTOLATEX_TEST_SLIDES_SCRIPT_ID`) or a separate Apps Script project, not production `Common`, `Docs`, or the live Slides add-on. Before any push, print the target `.clasp.json` script ID and say which env-var (if any) it matches, or that it cannot be classified because `.env` is missing.
 
 Do not create Apps Script versions, deployments, or ask the user to update Marketplace SDK App Configuration unless the user explicitly requests a production release or rollback. If a version/deployment is created by mistake, mark it as unused and do not tell the user to publish it.
 
@@ -47,6 +50,17 @@ node ../LibraryLinker.js unlink Docs
 ```
 
 Swap `Docs` for `Slides` or `Workspace` as needed.
+
+### Pushing Slides to a non-default script ID
+
+The checked-in `Slides/.clasp.json` always points at `AUTOLATEX_PROD_SLIDES_SCRIPT_ID` (the live Marketplace add-on). To push to `AUTOLATEX_PROD_SLIDES_VERSIONS_SCRIPT_ID` or `AUTOLATEX_TEST_SLIDES_SCRIPT_ID` instead:
+
+1. `cp Slides/.clasp.json Slides/.clasp.json.bak`
+2. Overwrite `Slides/.clasp.json` with `{"scriptId":"<target>"}` (the staging/test projects don't have GCP `projectId` linkage).
+3. Run `npm run clasp-push --common_version=<n> -- --force` from `Slides/`. The `--force` is needed because `clasp` sees the local tree as unchanged after the previous push and skips otherwise.
+4. Restore `Slides/.clasp.json` from `.clasp.json.bak` and delete the backup.
+
+Always restore before doing anything else — a left-over wrong script ID in `.clasp.json` is how a test push lands on the live add-on.
 
 ## Validation
 

--- a/skills/apps-script-push/SKILL.md
+++ b/skills/apps-script-push/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: apps-script-push
+description: Use when pushing this repo's Common, Docs, Slides, or Workspace projects to their remote Google Apps Script projects, especially when library linking, sidebar builds, or deployment/version confusion could cause a bad push.
+---
+
+# Apps Script Push
+
+Use this workflow for any request to push code from this repo to the remote Apps Script project.
+
+## Push Commands
+
+- `Common`: run `clasp push` from [Common/.clasp.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Common/.clasp.json).
+- `Docs`: run `npm run clasp-push` from [Docs/package.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Docs/package.json).
+- `Slides`: run `npm run clasp-push` from [Slides/package.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Slides/package.json).
+- `Workspace`: run `npm run clasp-push` from [Workspace/package.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Workspace/package.json).
+
+## Why `npm run clasp-push`
+
+For `Docs`, `Slides`, and `Workspace`, do not use raw `clasp push` by default.
+
+- The checked-in manifest keeps the `Common` library ID blank.
+- The `preclasp-push` script links the correct `Common` library ID.
+- `Docs` and `Slides` also rebuild `SidebarJS.html` before pushing.
+- The `postclasp-push` script unlinks the library ID again so git stays clean.
+
+Equivalent manual flow:
+
+```bash
+node ../LibraryLinker.js link Docs
+clasp push
+node ../LibraryLinker.js unlink Docs
+```
+
+Swap `Docs` for `Slides` or `Workspace` as needed.
+
+## Validation
+
+Before pushing:
+
+- Check `git status --short` and make sure only intended files are going up.
+- For Docs and Slides, confirm [BuildSidebarJS.js](/Users/aayushgupta/Documents/.projects.nosync/autolatex/BuildSidebarJS.js) has been run through the package script.
+
+After pushing:
+
+- Verify the remote project content with `clasp pull` into a temp directory or by inspecting the script editor.
+- If a behavior test still shows old code, assume the user is running an older deployment, not project head.
+
+## Deployment Caveat
+
+`clasp push` updates the Apps Script project head. It does not automatically update versioned deployments used by installed add-ons.
+
+If the user tests via an installed add-on or deployment URL:
+
+- create/update the Apps Script deployment after the push, or
+- have them test from the current project head in the script editor.
+
+If logs show an old version number after a push, the problem is usually deployment state, not the push itself.
+
+## Fallbacks
+
+- If `clasp push` fails with `Invalid ID`, the library was not linked. Use the package script or manual linker flow.
+- If the installed `clasp` is flaky and appears to skip files, verify by pulling the remote project into a temp directory before assuming the push worked.
+- If an Apps Script API push fallback is used, preserve remote-only files unless the user explicitly asks to remove them.

--- a/skills/apps-script-push/SKILL.md
+++ b/skills/apps-script-push/SKILL.md
@@ -14,6 +14,21 @@ Use this workflow for any request to push code from this repo to the remote Apps
 - `Slides`: run `npm run clasp-push` from [Slides/package.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Slides/package.json).
 - `Workspace`: run `npm run clasp-push` from [Workspace/package.json](/Users/aayushgupta/Documents/.projects.nosync/autolatex/Workspace/package.json).
 
+## Production Safety
+
+Treat production Apps Script projects as live user-impacting systems.
+
+Do not hard-code production script IDs in this skill. If production IDs are needed for target checks, load them from a local untracked `.env` file:
+
+- `AUTOLATEX_PROD_COMMON_SCRIPT_ID`
+- `AUTOLATEX_PROD_DOCS_SCRIPT_ID`
+
+Do not push test or debugging changes to these production projects unless the user explicitly asks for a production push or restore. This is especially important for `Common`: some already-published Docs versions may reference `Common` with `version: "0"` and `developmentMode: true`, so pushing `Common` HEAD can immediately change production behavior without a new Docs version or Marketplace publish.
+
+For testing, use a separate Apps Script project or deployment, not production `Common` or production `Docs`. Before any push, print the target `.clasp.json` script ID and say whether it matches a production ID from `.env`, is a non-production target, or cannot be classified because `.env` is missing.
+
+Do not create Apps Script versions, deployments, or ask the user to update Marketplace SDK App Configuration unless the user explicitly requests a production release or rollback. If a version/deployment is created by mistake, mark it as unused and do not tell the user to publish it.
+
 ## Why `npm run clasp-push`
 
 For `Docs`, `Slides`, and `Workspace`, do not use raw `clasp push` by default.
@@ -39,11 +54,14 @@ Before pushing:
 
 - Check `git status --short` and make sure only intended files are going up.
 - For Docs and Slides, confirm [BuildSidebarJS.js](/Users/aayushgupta/Documents/.projects.nosync/autolatex/BuildSidebarJS.js) has been run through the package script.
+- If pushing Docs, inspect the manifest that will be uploaded and verify `Common` is pinned to a numbered library version with `developmentMode: false` for production releases.
+- If `clasp push` prints `Skipping push`, do not create a new version from it. Either investigate why the push skipped or intentionally rerun with `--force` only after confirming the target is correct.
 
 After pushing:
 
 - Verify the remote project content with `clasp pull` into a temp directory or by inspecting the script editor.
 - If a behavior test still shows old code, assume the user is running an older deployment, not project head.
+- For production versions, verify the immutable version content through the Apps Script API or Script Editor before telling the user to publish it in GCP.
 
 ## Deployment Caveat
 

--- a/test/ALEStylesheet.html
+++ b/test/ALEStylesheet.html
@@ -1,0 +1,93 @@
+<style>
+  .logo1 {
+    width: 35%;
+  }
+
+  .credit_images {
+    justify-content: center;
+    display: flex;
+    margin-top: 10px;
+  }
+
+  .logo2 {
+    max-width: 40%;
+    max-height: 40%;
+  }
+  /* Dropdown Button */
+  .dropbtn {
+    background-color: #4caf50;
+    color: white;
+    padding: 16px;
+    font-size: 16px;
+    border: none;
+    cursor: pointer;
+  }
+
+  /* Dropdown button on hover & focus */
+  .dropbtn:hover,
+  .dropbtn:focus {
+    background-color: #3e8e41;
+  }
+
+  /* The container <div> - needed to position the dropdown content */
+  .dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  /* Dropdown Content (Hidden by Default) */
+  .dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  }
+
+  /* Links inside the dropdown */
+  .dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+  }
+
+  /* Change color of dropdown links on hover */
+  .dropdown-content a:hover {
+    background-color: #f1f1f1;
+  }
+
+  /* Show the dropdown menu (use JS to add this class to the .dropdown-content container when the user clicks on the dropdown button) */
+  .show {
+    display: block;
+  }
+
+  /**/
+  .branding-below {
+    position: absolute;
+    bottom: 20px;
+    top: 0;
+  }
+
+  .button-container {
+    display: flex;
+    flex-direction: column;
+    width: 248px;
+  }
+
+  .button-row {
+    display: flex;
+    margin: 0 5px 5px 0; /*top right bottom left*/
+    flex-grow: 1;
+    width: 248px;
+  }
+
+  .button-in-row1 {
+    margin: 0 8px 0 0; /* Alternatively: padding: 0 5px; */
+  }
+
+  .button-in-row2 {
+    margin: 3px 8px 0 0; /* Alternatively: padding: 0 5px; */
+    width: 248px;
+  }
+</style>

--- a/test/Code.js
+++ b/test/Code.js
@@ -1,0 +1,1074 @@
+/**
+ * @OnlyCurrentDoc
+ */
+//Auto-Latex Equations - (For api keys, ask aayush)
+
+var SIDEBAR_TITLE = "Auto-LaTeX Equations";
+var DEBUG = false; //doing ctrl + m to get key to see errors is still needed; DEBUG is for all nondiagnostic information
+var TIMING_DEBUG = false; //doing ctrl + m to get key to see errors is still needed; DEBUG is for all nondiagnostic information
+var previousTime = 0;
+var previousLine = 0;
+var equationRenderingTime = 0;
+var codecogsSlow = 0;
+var texrendrDown = 0;
+var capableRenderers = 8;
+var capableDerenderers = 12;
+//render bug variables
+var invalidEquationHashCodecogsFirst50 = "GIF89a%7F%00%18%00%uFFFD%00%00%uFFFD%u0315%uFFFD3%"; // invalid codecogs equation
+var invalidEquationHashCodecogsFirst50_2 = "";
+var invalidEquationHashCodecogsFirst50_3 = "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%01%"; // this is one space in codecogs. not pushed yet.
+var invalidEquationHashCodecogsFirst50_4 = "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0";
+var invalidEquationHashCodecogsFirst50_5 = "%uFFFDPNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00z%00";
+var invalidEquationHashTexrendrFirst50 = "GIF89a%uFFFD%008%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%";
+var invalidEquationHashTexrendrFirst50_2 = "GIF89a%01%00%01%00%uFFFD%00%00%uFFFD%uFFFD%uFFFD%0";
+var invalidEquationHashTexrendrFirst50_3 = "GIF89ai%0A%uFFFD%01%uFFFD%00%00%uFFFD%uFFFD%uFFFD%"; // this is the No Expression Supplied error. Ignored for now.
+var invalidEquationHashTexrendrFirst50_4 = "%7FELF%01%01%01%00%00%00%00%00%00%00%00%00%02%00%0";
+var invalidEquationHashSciweaversFirst50 = "%0D%0A%09%3C%21DOCTYPE%20html%20PUBLIC%20%22-//W3C";
+
+// IntegratedApp = {
+// 	getUi: function(){
+// 		let activeUi = DocumentApp.getUi();
+// 		return activeUi;
+// 	},
+// 	getBody: function(){
+// 		let activeBody = DocumentApp.getActiveDocument().getBody();
+// 		return activeBody;
+// 	},
+// 	getActive: function(){
+// 		let activeDoc = DocumentApp.getActiveDocument();
+// 		return activeDoc;
+// 	},
+// 	getPageWidth: function() {
+// 		let activeWidth = DocumentApp.getActiveDocument().getPageWidth();
+// 		return activeWidth;
+// 	}
+// };
+
+/** //8.03 - De-Render, Inline, Advanced Delimiters > Fixed Inline Not Appearing
+ * Creates a menu entry in the Google Docs UI when the document is opened.
+ *
+ * @param {object} e The event parameter for a simple onOpen trigger. To
+ *     determine which authorization mode (ScriptApp.AuthMode) the trigger is
+ *     running in, inspect e.authMode.
+ */
+function onOpen(e) {
+  DocumentApp.getUi().createAddonMenu().addItem("Start", "showSidebar").addToUi();
+}
+
+function reportDeltaTime(line = 0, forcePrint = "") {
+  var thisDate = new Date();
+  var thisTime = Number(thisDate.getTime()).toFixed(0);
+  if (!previousTime) previousTime = thisTime;
+  var deltaTime = thisTime - previousTime;
+  if (TIMING_DEBUG || forcePrint) {
+    if (line > 0) {
+      metadata = forcePrint ? " with metadata " + forcePrint : "";
+      console.log("Delta time is " + deltaTime + " on line " + line + " from previous line " + previousLine + metadata);
+    } else {
+      console.log("Delta time is " + deltaTime + " from previous line " + previousLine);
+    }
+  }
+  if (forcePrint) {
+    equationRenderingTime = deltaTime;
+  }
+  previousTime = thisTime;
+  previousLine = line;
+  return deltaTime;
+}
+
+/**
+ * Runs when the add-on is installed.
+ *
+ * @param {object} e The event parameter for a simple onInstall trigger. To
+ *     determine which authorization mode (ScriptApp.AuthMode) the trigger is
+ *     running in, inspect e.authMode. (In practice, onInstall triggers always
+ *     run in AuthMode.FULL, but onOpen triggers may be AuthMode.LIMITED or
+ *     AuthMode.NONE.)
+ */
+function onInstall(e) {
+  onOpen(e);
+}
+
+/**
+ * Opens a sidebar in the document containing the add-on's user interface.
+ */
+function showSidebar() {
+  var ui = HtmlService.createTemplateFromFile("Sidebar").evaluate().setTitle("Auto-LaTeX Equations").setSandboxMode(HtmlService.SandboxMode.IFRAME); // choose mode IFRAME which is fastest option
+  DocumentApp.getUi().showSidebar(ui);
+}
+
+//add to log
+function addLog(str) {
+  console.log(str);
+}
+
+/*
+ * Fetch the quality the user has selected
+ */
+function getPreferences() {
+  var userProperties = PropertiesService.getUserProperties();
+  var prefs = {
+    quality: userProperties.getProperty("delimiters"),
+    size: userProperties.getProperty("size"),
+  };
+  debugLog("delimiter prefs:" + prefs.delimiters);
+  debugLog("size prefs:" + prefs.size);
+  return prefs;
+}
+
+function encodeFlag(flag, renderCount) {
+  // return {flag: flag, renderCount: renderCount}
+  // let {flag, renderCount} = input
+  ans = 0;
+  if (flag == -2) {
+    ans = -2 - renderCount;
+  }
+  if (flag == -1) {
+    ans = -1;
+  }
+  if (flag == 0) {
+    ans = renderCount;
+  }
+  return ans;
+}
+/**
+ * Constantly keep replacing latex till all are finished
+ */
+function replaceEquations(sizeRaw, delimiter) {
+  // var obj = {flag: -2, renderCount: 0};
+  // return obj;
+  var quality = 900;
+  var size = getSize(sizeRaw);
+  var isInline = false;
+  if (size < 0) {
+    isInline = true;
+    size = 0;
+  }
+  reportDeltaTime(140);
+  var delim = getDelimiters(delimiter);
+  savePrefs(sizeRaw, delimiter);
+  var c = 0; //counter
+  var defaultSize = 11;
+  var allEmpty = 0;
+  reportDeltaTime(146);
+  var body;
+  try {
+    body = DocumentApp.getActiveDocument();
+  } catch (error) {
+    console.error(error);
+    return encodeFlag(-1, 0);
+  }
+
+  let childCount = body.getBody().getParent().getNumChildren();
+  reportDeltaTime(156);
+  for (var index = 0; index < childCount; index++) {
+    let failedStartElemIfIsEmpty = null;
+    while (true) {
+      // prevFailedStartElemIfIsEmpty is here so when $$$$ fails again and again, it doesn't get stuck there and moves on.
+      let [gotSize, returnedFailedStartElemIfIsEmpty] = findPos(index, delim, quality, size, defaultSize, isInline, failedStartElemIfIsEmpty); //or: "\\\$\\\$", "\\\$\\\$"
+      allEmpty = returnedFailedStartElemIfIsEmpty ? allEmpty + 1 : 0;
+      failedStartElemIfIsEmpty = returnedFailedStartElemIfIsEmpty;
+
+      if (allEmpty > 10) break; //Assume we quit on 10 consecutive empty equations.
+
+      if (gotSize == -100000)
+        // means all renderers didn't return/bugged out.
+        return encodeFlag(-2, c); // instead, return pair of number and bool flag in list but whatever
+
+      if (gotSize == 0) break; // finished with renders in this section
+
+      defaultSize = gotSize;
+      c = returnedFailedStartElemIfIsEmpty ? c : c + 1; // # of equations += 1 except empty equations
+      console.log("Rendered equations: " + c);
+    }
+  }
+  return encodeFlag(0, c);
+}
+
+/**
+ * Get position of insertion then place the image there.
+ * @param {string}  delim[6]     The text delimiters and regex delimiters for start and end in that order. E.g. ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1]
+
+ returns: [gotSize, isEmpty]
+				gotSize:
+					-100000 -> none of the renderers work
+					0 => failure finding delimiters, probably means last equation rendered
+					nonzero positive size => size to render equations at by default. also when there is a blank equation
+				isEmpty:
+					1 if eqn is "" and 0 if not. Assume we close on 4 consecutive empty ones.
+*/
+
+function findPos(index, delim, quality, size, defaultSize, isInline, prevFailedStartElemIfIsEmpty = null) {
+  debugLog("Checking document section index # ", index);
+  reportDeltaTime(195);
+  var docBody = getBodyFromIndex(index);
+  if (docBody == null) {
+    return [0, null];
+  }
+  var startElement = docBody.findText(delim[2]);
+  if (prevFailedStartElemIfIsEmpty) {
+    var startElement = docBody.findText(delim[2], prevFailedStartElemIfIsEmpty);
+  }
+  if (startElement == null) return [0, null]; //didn't find first delimiter
+  var placeHolderStart = startElement.getStartOffset(); //position of image insertion
+
+  var endElement = docBody.findText(delim[3], startElement);
+  if (endElement == null) return [0, null]; //didn't find end delimiter (maybe make error different?)
+  var placeHolderEnd = endElement.getEndOffsetInclusive(); //text between placeHolderStart and placeHolderEnd will be permanently deleted
+  debugLog(delim[2], " single escaped delimiters ", placeHolderEnd - placeHolderStart, " characters long");
+
+  reportDeltaTime(214);
+  if (placeHolderEnd - placeHolderStart == 2.0) {
+    // empty equation
+    console.log("Empty equation! In index " + index + " and offset " + placeHolderStart);
+    return [defaultSize, endElement]; // default behavior of placeImage
+  }
+
+  return placeImage(index, startElement, placeHolderStart, placeHolderEnd, quality, size, defaultSize, delim, isInline);
+}
+
+function assert(value, command = "unspecified") {
+  if (value == false) {
+    console.error("Assert failed! When doing ", command);
+  }
+}
+
+//encode function that gets Missed. Google Docs characters stuff
+function getCustomEncode(equation, direction, time) {
+  // there are two sublists because they happen at differeent times (on encode or decoded string).
+  // In addition, the second set is one way due to typing errors/unsupported characters.
+  // Replace the first array just for the accompanying link. 	%C2%AD is better than %A0
+  // Note newlines are also %0A or %0D or %0D%0A
+  var toFind = [
+    ["#", "+", "%0D", "%0D", "%0D"],
+    ["‘", "’", "”", "“", "−", "≥", "≤", "‐", "—"],
+  ];
+  var toReplace = [
+    ["+%23", "+%2B", "%5C%5C%5C%5C%20", "%5C%5C%20", "%A0"],
+    ["'", "'", '"', '"', "-", "\\geq", "\\leq", "-", "-"],
+  ]; //&hash;&plus; todo ≥ with \geq
+  assert(toFind[time].length == toReplace[time].length, "toFind[time].length == toReplace[time].length");
+  for (var i = 0; i < toFind[time].length; ++i) {
+    if (direction == 0) equation = equation.split(toFind[time][i]).join(toReplace[time][i]);
+    else if (direction == 1 && time == 0) {
+      // the single, double quotes, and hyphens should stay minus signs.
+      equation = equation.split(toReplace[time][i]).join(toFind[time][i]);
+    }
+  }
+  return equation;
+}
+//
+//The one indexed 3rd rendering service needs this for file names
+function getFilenameEncode(equation, direction) {
+  var toFind = ["+", "'", "%", "(", ")", "&", ";", ".", "~", "*", "{", "}"];
+  var toReplace = ["†", "‰27", "‰", "‹", "›", "§", "‡", "•", "˜", "ª", "«", "»"];
+  for (var i = 0; i < Math.min(toFind.length, toReplace.length); ++i) {
+    if (direction == 0) equation = equation.split(toFind[i]).join(toReplace[i]);
+    else if (direction == 1) equation = equation.split(toReplace[i]).join(toFind[i]);
+  }
+  return equation;
+}
+/**
+ * Retrives the equation from the paragraph, encodes it, and returns it.
+ *
+ * @param {element} paragraph  The paragraph which the child is in.
+ * @param {integer} childIndex The childIndex in the paragraph where the text is in.
+ * @param {integer} start      The offset in the childIndex where the equation delimiters start.
+ * @param {integer} end        The offset in the childIndex where the equation delimiters end.
+ */
+function reEncode(equation) {
+  equation = getCustomEncode(equation, 0, 1);
+  var equationStringEncoded = getCustomEncode(encodeURIComponent(equation), 0, 0); //escape deprecated
+  return equationStringEncoded;
+}
+
+function deEncode(equation) {
+  reportDeltaTime(269);
+  debugLog(equation);
+  debugLog(getCustomEncode(getFilenameEncode(equation, 1), 1, 0));
+  debugLog(decodeURIComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0)));
+
+  reportDeltaTime(274);
+  var equationStringDecoded = decodeURIComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0)); //escape deprecated
+  //  console.log("Decoded without replacing: " + equationStringDecoded);
+  var equationStringDecoded = getCustomEncode(equationStringDecoded, 1, 1);
+  debugLog("Decoded with replacing: " + equationStringDecoded);
+  return equationStringDecoded;
+}
+
+function getEquation(paragraph, childIndex, start, end, delimiters) {
+  var equationOriginal = [];
+  reportDeltaTime(284);
+  debugLog("See text", paragraph.getChild(childIndex).getText(), paragraph.getChild(childIndex).getText().length);
+  var equation = paragraph
+    .getChild(childIndex)
+    .getText()
+    .substring(start + delimiters[4], end - delimiters[4] + 1);
+  debugLog("See equation", equation);
+  var equationStringEncoded = reEncode(equation); //escape deprecated
+  equationOriginal.push(equationStringEncoded);
+  reportDeltaTime(290);
+  //console.log("Encoded: " + equationStringEncoded);
+  return equationStringEncoded;
+}
+
+/**
+ * Using the encoded equation, add the commands for high quality, inline or not (based on size neg or pos), and returns it.
+ *
+ * @param {string}  equationStringEncoded  The encoded equation.
+ * @param {integer} quality                The dpi quality to be rendered in (default 900).
+ * @param {string}  inlineStyle            The text to be inserted for inline text, dependent on CodeCogs or TeXRendr.
+ * @param {integer} size                   The size of the text, whose neg/pos indicated whether the equation is inline or not.
+ */
+
+function getStyle(equationStringEncoded, quality, renderer, isInline, type) {
+  //ERROR?
+  var equation = [];
+  equationStringEncoded = equationStringEncoded;
+  reportDeltaTime(307);
+  if (isInline) equationStringEncoded = renderer[3] + equationStringEncoded + renderer[4];
+  if (type == 2) {
+    equationStringEncoded = equationStringEncoded.split("&plus;").join("%2B"); //HACKHACKHACKHACK REPLACE
+    equationStringEncoded = equationStringEncoded.split("&hash;").join("%23"); //HACKHACKHACKHACK REPLACE
+  }
+  //console.log('Equation Final: ' + equationStringEncoded);
+  equation.push(equationStringEncoded);
+  reportDeltaTime(315);
+  return equationStringEncoded;
+}
+
+function savePrefs(size, delim) {
+  var userProperties = PropertiesService.getUserProperties();
+  userProperties.setProperty("size", size);
+  userProperties.setProperty("delim", delim);
+  // userProperties.setProperty('defaultSize', size);
+}
+
+function getPrefs() {
+  var userProperties = PropertiesService.getUserProperties();
+  var savedPrefs = {
+    size: userProperties.getProperty("size"),
+    delim: userProperties.getProperty("delim"),
+  };
+  debugLog("Got prefs size:" + savedPrefs.size);
+  return savedPrefs;
+}
+
+function getKey() {
+  console.log("Got Key: " + Session.getTemporaryActiveUserKey() + " and email " + Session.getEffectiveUser().getEmail());
+  return Session.getTemporaryActiveUserKey();
+}
+
+//retrieve size from text
+function setSize(size, defaultSize, paragraph, childIndex, start) {
+  //GET SIZE
+  let newSize = size;
+  if (size == 0) {
+    try {
+      newSize = paragraph
+        .getChild(childIndex)
+        .editAsText()
+        .getFontSize(start + 3); //Fix later: Change from 3 to 1
+    } catch (err) {
+      newSize = paragraph
+        .getChild(childIndex)
+        .editAsText()
+        .getFontSize(start + 1); //Fix later: Change from 3 to 1
+    }
+    // size = paragraph.getChild(childIndex).editAsText().getFontSize(start+1);//Fix later: Change from 3 to 1
+    // console.log("New size is " + size); //Causes: Index (3) must be less than the content length (2).
+    if (newSize == null || newSize <= 0) {
+      console.log("Null size! Assigned " + defaultSize);
+      newSize = defaultSize;
+    }
+  }
+  //console.log("Found Size In Doc As " + size);
+  return newSize;
+}
+
+// deprecated, use the indexing method to get all odd/even footers etc. as well
+function getBodyFromLocation(location) {
+  var docBody;
+  reportDeltaTime(365);
+  if (location == "header") {
+    docBody = DocumentApp.getActiveDocument().getHeader();
+  }
+  if (location == "body") {
+    docBody = DocumentApp.getActiveDocument().getBody();
+  }
+  if (location == "footer") {
+    docBody = DocumentApp.getActiveDocument().getFooter();
+    // debugLog("Got footer ", docBody.getText(), docBody.getType() === DocumentApp.ElementType.FOOTER_SECTION, docBody.getType() === DocumentApp.ElementType.HEADER_SECTION)
+    // debugLog(docBody.getParent().getChild(0).getType() === DocumentApp.ElementType.BODY_SECTION, docBody.getParent().getChild(0).getType() === DocumentApp.ElementType.HEADER_SECTION )
+  }
+  reportDeltaTime(377);
+  return docBody;
+}
+
+// to get doc section from index (i.e. header, footer, body etc)
+function getBodyFromIndex(index) {
+  var doc = DocumentApp.getActiveDocument();
+  var p = doc.getBody().getParent();
+  var all = p.getNumChildren();
+  assert(index < all, "index < all");
+  body = p.getChild(index);
+  var type = body.getType();
+  if (type === DocumentApp.ElementType.BODY_SECTION || type === DocumentApp.ElementType.HEADER_SECTION || type === DocumentApp.ElementType.FOOTER_SECTION) {
+    // handles alternating footers etc.
+    return body;
+  }
+  return null;
+}
+
+//function blobIsCCFailure(blob){
+//  return escape(resp.getBlob().getDataAsString()).substring(0,50) == invalidEquationHashCodecogsFirst50
+//}
+/**
+ * Given the locations of the delimiters, run code to get font size, get equation, remove equation, encode/style equation, insert/style image.
+ *
+ * @param {element} startElement The paragraph which the child is in.
+ * @param {integer} start        The offset in the childIndex where the equation delimiters start.
+ * @param {integer} end          The offset in the childIndex where the equation delimiters end.
+ * @param {integer} quality      The dpi quality to be rendered in (default 900).
+ * @param {integer} size         The size of the text, whose neg/pos indicated whether the equation is inline or not.
+ * @param {integer} defaultSize  The default/previous size of the text, in case size is null.
+ * @param {string}  delim[6]     The text delimiters and regex delimiters for start and end in that order, and offset from front and back.
+ */
+
+function placeImage(index, startElement, start, end, quality, size, defaultSize, delim, isInline) {
+  reportDeltaTime(411);
+  var docBody = getBodyFromIndex(index);
+  reportDeltaTime(413);
+  // GET VARIABLES
+  var textElement = startElement.getElement();
+  var text = textElement.getText();
+  var paragraph = textElement.getParent();
+  var childIndex = paragraph.getChildIndex(textElement); //gets index of found text in paragaph
+  size = setSize(size, defaultSize, paragraph, childIndex, start);
+  var equationOriginal = getEquation(paragraph, childIndex, start, end, delim);
+
+  if (equationOriginal == "") {
+    console.log("No equation but undetected start and end as ", start, " ", end);
+    return [defaultSize, startElement];
+  }
+
+  var equation = "";
+  var renderer = getRenderer(1);
+  var resp;
+  var worked = 1;
+  var failure = 1;
+  var rendererType = "";
+
+  var failedCodecogs = 0;
+  var failedTexrendr = 0;
+  var failedResp;
+  // if only failed codecogs, probably weird evening bug from 10/15/19
+  // if failed codecogs and texrendr, probably shitty equation and the codecogs error is more descriptive so show it
+
+  // note the last few renderers might be legacy, so ignored
+  for (; worked <= capableRenderers; ++worked) {
+    //[3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
+    try {
+      renderer = getRenderer(worked);
+      rendererType = renderer[5];
+      equation = getStyle(equationOriginal, quality, renderer, isInline, worked);
+      // console.log(rendererType, "Texrendr", rendererType == "Texrendr")
+      if (rendererType == "Texrendr") {
+        // console.log("Used texrendr", equation, equation.replace("%5C%5C", "%0D"))
+        equation = equation.split("%A0").join("%0D"); //.replace("%5C%5C", "%0D") .replace("%C2%AD", "%0D")
+      } else if (rendererType == "Codecogs") {
+        // console.log("Used Codecogs", equation, equation.split("%5C%5C%5C%5C").join("%5C%5C"))
+        equation = equation.split("%5C%5C%5C%5C").join("%5C%5C"); //.replace("%A0", "%0D") .replace("%C2%AD", "%0D")
+      } else if (rendererType == "Sciweavers") {
+        // console.log("Used Sciweavers", equation, equation.split("%5C%5C%5C%5C").join("%5C%5C"))
+        equation = equation.split("%5C%5C%5C%5C").join("%5C%5C"); //.replace("%A0", "%0D") .replace("%C2%AD", "%0D")
+      }
+
+      debugLog("Raw equation", equation);
+      renderer[1] = renderer[1].split("FILENAME").join(getFilenameEncode(equation, 0));
+      renderer[1] = renderer[1].split("EQUATION").join(equation);
+      renderer[2] = renderer[2].split("FILENAME").join(getFilenameEncode(equation, 0)); // since mutating original object, important each is a new one
+      debugLog("Link with equation", renderer[1]);
+      // console.log("Link with equation", renderer[1]);
+
+      reportDeltaTime(453);
+      // if(equation.indexOf("align")>-1 && rendererType != 'Codecogs'){
+      // 	continue; // dont even try to render align equatoins with texrendr
+      // }
+      console.log("Fetching ", renderer[1], " and ", renderer[2] + renderer[6] + equation);
+
+      var _createFileInCache = UrlFetchApp.fetch(renderer[2] + renderer[6] + equation);
+      // needed for codecogs to generate equation properly, need to figure out which other renderers need this. to test, use align* equations.
+
+      reportDeltaTime(458, " fetching w eqn len " + equation.length + " with renderer " + rendererType);
+      let didTimeOut = true;
+      if (rendererType == "Codecogs" || rendererType == "Sciweavers") {
+        Utilities.sleep(50); // sleep 50ms to let codecogs put the equation in its cache
+      }
+      resp = UrlFetchApp.fetch(renderer[1]);
+      didTimeOut = false;
+      debugLog(resp, resp.getBlob(), escape(resp.getBlob().getDataAsString()).substring(0, 50));
+      deltaTime = reportDeltaTime(470, " equation link length " + renderer[1].length + " and renderer  " + rendererType);
+      console.log("Hash ", escape(resp.getBlob().getDataAsString()).substring(0, 50));
+      if (escape(resp.getBlob().getDataAsString()) == invalidEquationHashCodecogsFirst50_2) {
+        // if there is no hash, codecogs failed
+        throw new Error("Saw NO Codecogs equation hash! Renderer likely down!");
+      } else if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashSciweaversFirst50) {
+        // if there is no hash, codecogs failed
+        throw new Error("Saw weburl Sciweavers equation hash! Equation likely contains amsmath!");
+      } else if (
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_3 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_4 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50_5
+      ) {
+        console.log("Invalid Codecogs Equation!");
+        failedCodecogs += 1;
+        failedResp = resp;
+        if (failedCodecogs && failedTexrendr) {
+          // if in order so failed codecogs first
+          console.log("Displaying codecogs error!");
+          resp = failedResp; // let it continue to completion with the failed codecogs equation
+        } else {
+          throw new Error("Saw invalid Codecogs equation hash!");
+        }
+      } // have no idea if I can put an else here or not lol
+      if (
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_2 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_3 ||
+        escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashTexrendrFirst50_4
+      ) {
+        console.log("Invalid Texrendr Equation! Times: " + failedCodecogs + failedTexrendr);
+        failedTexrendr += 1;
+        if (failedCodecogs && failedTexrendr) {
+          // if in order so failed codecogs first
+          console.log("Displaying Texrendr error!");
+          resp = failedResp; // let it continue to completion with the failed codecogs equation
+        } else {
+          // should only execute if texrendr is 1
+          throw new Error("Saw invalid Texrendr equation hash!");
+        }
+      }
+      if (deltaTime > 10000 && rendererType == "Codecogs" && renderer[0] <= 3) {
+        console.log("Codecogs accurate but is slow! Switching renderer priority.");
+        codecogsSlow = 1;
+      }
+      failure = 0;
+      console.log("Worked with renderer ", worked, " and type ", rendererType);
+      break;
+    } catch (err) {
+      console.log(rendererType + " Error! - " + err);
+      deltaTime = reportDeltaTime(533, " failed equation link length " + renderer[1].length + " and renderer  " + rendererType);
+      if (rendererType == "Texrendr") {
+        // equation.indexOf("align")==-1 &&  removed since align now supported
+        console.log("Texrendr likely down, deprioritized!");
+        texrendrDown = 1;
+      }
+    }
+    if (failure == 0) break;
+  }
+  if (worked > capableRenderers) return [-100000, null];
+  // SAVING FORMATTING
+  reportDeltaTime(511);
+  if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50) {
+    worked = 1; //assumes codecogs is 1
+    renderer = getRenderer(worked);
+    rendererType = renderer[5];
+  }
+  reportDeltaTime(517);
+  var textCopy = textElement.asText().copy();
+  var endLimit = end;
+  if (text.length - 1 < endLimit) endLimit = text.length - 1;
+  textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
+  reportDeltaTime(522);
+  textElement.editAsText().deleteText(start, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
+  var logoBlob = resp.getBlob();
+  var attemptsToInsertImageLeft = 50;
+  reportDeltaTime(526);
+
+  try {
+    paragraph.insertInlineImage(childIndex + 1, logoBlob); // TODO ISSUE: sometimes fails because it times out and yeets
+    returnParams = repairImage(index, startElement, paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal);
+    return returnParams;
+  } catch (err) {
+    console.log("Could not insert image try 1");
+    console.error(err);
+  }
+  reportDeltaTime(536);
+  try {
+    Utilities.sleep(1000);
+    paragraph.insertInlineImage(childIndex + 1, logoBlob); // TODO ISSUE: sometimes fails because it times out and yeets
+    returnParams = repairImage(index, startElement, paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal);
+    return returnParams;
+  } catch (err) {
+    console.log("Could not insert image try 2 after 1000ms");
+    console.error(err);
+  }
+  throw new Error("Could not insert image at childindex!");
+  // return repairImage(index, startElement, paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal);
+}
+
+function repairImage(index, startElement, paragraph, childIndex, size, defaultSize, renderer, delim, textCopy, resp, rendererType, equation, equationOriginal) {
+  var attemptsToSetImageUrl = 3;
+  reportDeltaTime(552); // 3 seconds!! inserting an inline image takes time
+  while (attemptsToSetImageUrl > 0) {
+    try {
+      paragraph.getChild(childIndex + 1).setLinkUrl(renderer[2] + equationOriginal + "#" + delim[6]); //added % delim 6 to keep track of which delimiter was used to render
+      break;
+    } catch (err) {
+      console.log("Couldn't insert child index!");
+      console.log("Next child not found!");
+      --attemptsToSetImageUrl;
+    }
+  }
+  if (attemptsToSetImageUrl < 3) {
+    console.log("At ", attemptsToSetImageUrl, " attemptsToSetImageUrls of failing to get child and link , ", equation);
+    if (attemptsToSetImageUrl == 0) {
+      throw new Error("Couldn't get equation child!"); // of image immediately after inserting
+    }
+  }
+
+  reportDeltaTime(570);
+  if (textCopy.getText() != "") paragraph.insertText(childIndex + 2, textCopy); // reinsert deleted text after the image, with all the formatting
+  var height = paragraph.getChild(childIndex + 1).getHeight();
+  var width = paragraph.getChild(childIndex + 1).getWidth();
+  console.log("Pre-fixing size, width, height: " + size + ", " + width + ", " + height); //only a '1' is rendered as a 100 height (as of 10/20/19, now it is fetched as 90 height). putting an equationrendertime here just doesnt work
+
+  //SET PROPERTIES OF IMAGE (Height, Width)
+  var oldSize = size; // why use oldsize instead of new size
+
+  if (escape(resp.getBlob().getDataAsString()).substring(0, 50) == invalidEquationHashCodecogsFirst50 || (size > 10 && width == 126 && height == 24)) {
+    size *= 5; // make codecogs errors readable, size constraint just in case some small equation is 126x24 as well
+  }
+  // console.log(rendererType, rendererType.valueOf(), "Texrendr".valueOf(), rendererType.valueOf() === "Codecogs".valueOf(), rendererType.valueOf() == "Codecogs".valueOf(), rendererType === "Codecogs", rendererType.valueOf() === "Texrendr".valueOf(), rendererType.valueOf() == "Texrendr".valueOf(), rendererType === "Texrendr")
+  // note that valueOf here is not needed, and neither is === => removing both keeps trues true and falses false in V8.
+
+  // if(rendererType.valueOf() === "Texrendr".valueOf())  //Old TexRendr
+  // 	size = Math.round(size * height / 174);
+  let multiple = size / 100.0;
+  if (rendererType.valueOf() === "Texrendr".valueOf())
+    //TexRendr
+    multiple = size / 42.0;
+  else if (rendererType.valueOf() === "Roger's renderer".valueOf())
+    //Rogers renderer
+    multiple = size / 200.0;
+  else if (rendererType.valueOf() === "Codecogs".valueOf())
+    //CodeCogs, other
+    multiple = size / 100.0;
+  else if (rendererType.valueOf() === "Sciweavers".valueOf())
+    //Scieweavers
+    multiple = size / 98.0;
+  else if (rendererType.valueOf() === "Sciweavers_old".valueOf())
+    //C [75.4, 79.6] on width and height ratio
+    multiple = size / 76.0;
+  //CodeCogs, other
+  else multiple = size / 100.0;
+
+  size = Math.round(height * multiple);
+  reportDeltaTime(595);
+  sizeImage(paragraph, childIndex + 1, size, Math.round(width * multiple));
+  defaultSize = oldSize;
+  return [defaultSize, null];
+}
+
+/**
+ * Given the locations of the delimiters, run code to get font size, get equation, remove equation, encode/style equation, insert/style image.
+ *
+ * @param {element} paragraph  The paragraph which the child is in.
+ * @param {integer} childIndex The childIndex in the paragraph where the text is in, to give the place to edit image.
+ * @param {integer} height     The scaled height of the equation based on font size.
+ * @param {integer} width      The scaled width of the equation based on font size.
+ */
+
+function sizeImage(paragraph, childIndex, height, width) {
+  var maxWidth = DocumentApp.getActiveDocument().getPageWidth();
+  //console.log("Max Page Width: " + maxWidth);
+  if (width > maxWidth) {
+    height = Math.round((height * maxWidth) / width);
+    width = maxWidth;
+    console.log("Rescaled in page.");
+  }
+  if (childIndex == null || width == 0 || height == 0) {
+    console.log("none or 0 width hight");
+    return;
+  }
+  paragraph.getChild(childIndex).setHeight(height);
+  paragraph.getChild(childIndex).setWidth(width);
+  // paragraph.getChild(childIndex).scaleHeight(multiple);
+  // paragraph.getChild(childIndex).scaleWidth(multiple);
+}
+
+/**
+ * Given a size and a cursor right before an equation, call function to undo the image within delimeters. Returns success indicator.
+ *
+ * @param {string} sizeRaw     Sidebar-selected size.
+ */
+
+function removeEquations(sizeRaw, delimiter) {
+  var quality = 900;
+  var size = getSize(sizeRaw);
+  var delim = getDelimiters(delimiter);
+  savePrefs(sizeRaw, delimiter);
+  var equationsDerenderedCount = 0;
+  equationsDerenderedCount += removeAll(delim);
+  console.log("Derendered this many equations: " + equationsDerenderedCount);
+  return equationsDerenderedCount;
+}
+
+/**
+ * Given a size and a cursor right before an equation, call function to undo the image within delimeters. Returns success indicator.
+ *
+ * @param {string} sizeRaw     Sidebar-selected size.
+ */
+
+function editEquations(sizeRaw, delimiter) {
+  var quality = 900;
+  var size = getSize(sizeRaw);
+  var delim = getDelimiters(delimiter);
+  savePrefs(sizeRaw, delimiter);
+  var toReturn = undoImage(delim);
+  console.log("Undoimage return flag: " + toReturn);
+  return toReturn;
+}
+
+/**
+ * Given string of size, return integer value.
+ *
+ * @param {string} sizeRaw     The text value of the size from HTML selection.
+ */
+
+function getSize(sizeRaw) {
+  var size = 0;
+  if (sizeRaw == "smart") {
+    size = 0;
+  }
+  if (sizeRaw == "inline") {
+    size = -1;
+  }
+  if (sizeRaw == "med") {
+    size = 24;
+  }
+  if (sizeRaw == "low") {
+    size = 12;
+  }
+  return size;
+}
+
+// NOTE: one indexed. if codecogsSlow is 1, switch order of texrendr and codecogs
+function getRenderer(worked) {
+  //  order of execution ID, image URL, editing URL, in-line commandAt the beginning, in-line command at and, Human name, the part that gets rendered in browser in the fake call but not in the link(No Machine name substring)
+  codeCogsPriority = 1;
+  sciWeaverPriority = 4;
+  texRenderPriority = 5;
+  if (codecogsSlow) {
+    sciWeaverPriority = 1;
+    codeCogsPriority = 3;
+    texRenderPriority = 2;
+  } //t , c, s
+  // if(texrendrDown){
+  // 	temp = sciWeaverPriority
+  // 	sciWeaverPriority = texRenderPriority
+  // 	texRenderPriority = temp
+  // } // s, c, t or c, s, t
+  // texRenderPriority = 2
+  // codeCogsPriority = 3
+  // sciWeaverPriority = 2
+  // sciWeaverPriority = 1
+  capableRenderers = 8;
+  capableDerenderers = 12;
+  if (worked == codeCogsPriority) {
+    return [
+      codeCogsPriority,
+      "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
+      "https://www.codecogs.com/eqnedit.php?latex=",
+      "%5Cinline%20",
+      "",
+      "Codecogs",
+      "%5Cdpi%7B900%7D",
+    ];
+  } else if (worked == codeCogsPriority + 1) {
+    return [
+      codeCogsPriority + 1,
+      "https://latex-staging.easygenerator.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
+      "https://latex-staging.easygenerator.com/eqneditor/editor.php?latex=",
+      "%5Cinline%20",
+      "",
+      "Codecogs",
+      "%5Cdpi%7B900%7D",
+    ];
+  } else if (worked == codeCogsPriority + 2) {
+    return [
+      codeCogsPriority + 2,
+      "https://latex.codecogs.com/gif.latex?%5Cdpi%7B900%7DEQUATION",
+      "https://www.codecogs.com/eqnedit.php?latex=",
+      "%5Cinline%20",
+      "",
+      "Codecogs",
+      "%5Cdpi%7B900%7D",
+    ];
+  } else if (worked == texRenderPriority) {
+    return [texRenderPriority, "http://texrendr.com/cgi-bin/mimetex?%5CHuge%20EQUATION", "http://www.texrendr.com/?eqn=", "%5Ctextstyle%20", "", "Texrendr", ""];
+  } //http://rogercortesi.com/eqn/index.php?filename=tempimagedir%2Feqn3609.png&outtype=png&bgcolor=white&txcolor=black&res=900&transparent=1&antialias=1&latextext=  //removed %5Cdpi%7B900%7D
+  else if (worked == sciWeaverPriority) {
+    return [
+      sciWeaverPriority,
+      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=EQUATION",
+      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=jpg&fs=100&ff=modern&edit=0&eq=",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Sciweavers",
+      "",
+    ];
+  } //not latex font
+  else if (worked == 6) {
+    return [
+      6,
+      "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION",
+      "https://www.codecogs.com/eqnedit.php?latex=",
+      "%5Cinline%20",
+      "",
+      "Codecogs",
+      "%5Cdpi%7B900%7D",
+      "",
+    ];
+  } else if (worked == 7) {
+    return [
+      7,
+      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=EQUATION",
+      "http://www.sciweavers.org/tex2img.php?bc=Transparent&fc=Black&im=png&fs=100&ff=iwona&edit=0&eq=",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Sciweavers",
+      "",
+    ];
+  } // here to de render legacy equations properly, don't remove without migrating to correct font!
+  else if (worked == 8) {
+    return [
+      8,
+      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=EQUATION",
+      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=png&fs=100&ff=anttor&edit=0&eq=",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Sciweavers",
+      "",
+    ];
+  } // here to de render legacy equations properly, don't remove without migrating to correct font!
+  else if (worked == 9) {
+    return [
+      9,
+      "http://rogercortesi.com/eqn/tempimagedir/_FILENAME.png",
+      "http://rogercortesi.com/eqn/index.php?filename=_FILENAME.png&outtype=png&bgcolor=white&txcolor=black&res=1800&transparent=1&antialias=0&latextext=",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Roger's renderer",
+      "",
+    ];
+  } //Filename has to not have any +, Avoid %,Instead use†‰, avoid And specific ASCII Percent codes
+  else if (worked == 10) {
+    return [10, "https://texrendr.com/cgi-bin/mathtex.cgi?%5Cdpi%7B1800%7DEQUATION", "https://www.texrendr.com/?eqn=", "%5Ctextstyle%20", "", "Texrendr", ""];
+  } // here to de render legacy equations properly,  //http://rogercortesi.com/eqn/index.php?filename=tempimagedir%2Feqn3609.png&outtype=png&bgcolor=white&txcolor=black&res=900&transparent=1&antialias=1&latextext=  //removed %5Cdpi%7B900%7D
+  else if (worked == 11) {
+    return [
+      11,
+      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=EQUATION",
+      "http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=jpg&fs=78&ff=arev&edit=0&eq=",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Sciweavers_old",
+      "",
+    ];
+  } // here to de render legacy equations properly, don't remove without migrating to correct font!
+  else if (worked == 12) {
+    return [
+      12,
+      "http://latex.numberempire.com/render?EQUATION&sig=41279378deef11cbe78026063306e50d",
+      "http://latex.numberempire.com/render?",
+      "%5Ctextstyle%20%7B",
+      "%7D",
+      "Number empire",
+      "",
+    ];
+  } // to de render possibly very old equations
+  else return [0, "https://latex.codecogs.com/png.latex?%5Cdpi%7B900%7DEQUATION", "https://www.codecogs.com/eqnedit.php?latex=", "%5Cinline%20", "", "Codecogs", "%5Cdpi%7B900%7D"];
+} //http://www.sciweavers.org/tex2img.php?bc=White&fc=Black&im=jpg&fs=78&ff=txfonts&edit=0&eq=
+/**
+ * Given string of size, return integer value.
+ *
+ * @param {string} delimiters     The text value of the delimiters from HTML selection.
+ */
+
+function getDelimiters(delimiters) {
+  // Todo - fix hardcoded delimiters. Potentially do escape(escape(original)) or something like that.
+  if (delimiters == "$$") {
+    return ["$$", "$$", "\\$\\$", "\\$\\$", 2, 1, 0];
+  } //raw begin, raw end, escaped begin, escaped end, # of chars, idk, renderer type #
+  if (delimiters == "[") {
+    return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
+  }
+  if (delimiters == "$") {
+    return ["$", "$", "[^\\\\]\\$", "[^\\\\]\\$", 1, 0, 2];
+  } //(^|[^\\$])\$(?!\$) //(?:^|[^\\\\\\])\\\$ //[^\\\\]\\\$
+  if (delimiters == "(") {
+    return ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3];
+  }
+  return ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1];
+}
+
+function getNumDelimiters(delimiters) {
+  // //HARDCODED DELIMTERS!!!!!!!!!!!!!
+  if (delimiters == "0") {
+    return "$$";
+  } //reverse lookup index 6 of array from above method
+  if (delimiters == "1") {
+    return "[";
+  }
+  if (delimiters == "2") {
+    return "$";
+  }
+  if (delimiters == "3") {
+    return "(";
+  }
+  return "$$";
+}
+
+function debugLog(...strings) {
+  if (DEBUG) {
+    console.log(...strings);
+  }
+}
+
+/**
+ * Given a cursor right before an equation, de-encode URL and replace image with raw equation between delimiters.
+ *
+ * @param {[string, string]} delim     Start/end delimiters to insert.
+ */
+function removeAll(delimRaw) {
+  counter = 0;
+  var delim = getDelimiters(delimRaw);
+  for (var index = 0; index < DocumentApp.getActiveDocument().getBody().getParent().getNumChildren(); index++) {
+    var body = getBodyFromIndex(index);
+    var img = body.getImages(); //places all InlineImages from the active document into the array img
+    for (i = 0; i < img.length; i++) {
+      var image = img[i];
+      var origURL = new String(image.getLinkUrl()); //becomes "null", not null, if no equation link
+      if (image.getLinkUrl() === null) {
+        continue;
+      }
+      // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
+      // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
+      var origEq;
+      var worked = 1;
+      var failure = 1;
+      var found = 0;
+      for (; worked <= capableDerenderers; ++worked) {
+        // example, [3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
+        renderer = getRenderer(worked)[2].split("FILENAME"); //list of possibly more than one string
+        for (var I = 0; I < renderer.length; ++I) {
+          if (origURL.indexOf(renderer[I]) > -1) {
+            debugLog("Changing: " + origURL + " by removing " + renderer[I]);
+            origURL = origURL.substring(origURL.indexOf(renderer[I])).split(renderer[I]).join(""); //removes prefix
+            found = 1;
+          } else break;
+        }
+      }
+      if (found == 0) {
+        console.log("Not an equation link! " + origURL, origURL.indexOf(renderer[0]), origURL.indexOf(renderer[1]));
+        continue; // not an equation link
+      }
+      var last2 = origURL.slice(-2);
+      var delimtype = 0;
+      if (last2.length > 1 && (last2.charAt(0) == "%" || last2.charAt(0) == "#") && last2.charAt(1) >= "0" && last2.charAt(1) <= "9") {
+        //rendered with updated renderer
+        debugLog("Passed: " + last2);
+        delimtype = last2.charAt(1) - "0";
+        origURL = origURL.slice(0, -2);
+        delim = getDelimiters(getNumDelimiters(delimtype));
+      }
+      var origEq = deEncode(origURL);
+      debugLog("Undid: " + origEq);
+      var imageIndex = image.getParent().getChildIndex(image);
+      if (origEq.length <= 0) {
+        console.log("Empty. at " + imageIndex + " fold " + image.getParent().getText());
+        image.removeFromParent();
+        continue;
+      }
+      image.getParent().insertText(imageIndex, delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+      image.removeFromParent();
+      counter += 1;
+    }
+  }
+  return counter;
+}
+
+/* Returns: -4 if the URL is null (link removed for instance)
+						-3 if empty equation derender
+						-2 if the element the cursor is in doesnt exist
+						-1 if cursor element is not found (?)
+						0 if cursor not found entirely
+						1 if it was fine
+*/
+function undoImage(delim) {
+  var cursor = DocumentApp.getActiveDocument().getCursor();
+  if (cursor) {
+    // Attempt to insert text at the cursor position. If the insertion returns null, the cursor's
+    // containing element doesn't allow insertions, so show the user an error message.
+    var element = cursor.getElement(); //startElement
+
+    if (element) {
+      console.log("Valid cursor.");
+
+      var position = cursor.getOffset(); //offset
+      //element.getChild(position).removeFromParent();  //SUCCESSFULLY REMOVES IMAGE FROM PARAGRAPH
+      // console.log(element.getAllContent(), element.type())
+      var image = element.getChild(position).asInlineImage();
+      debugLog("Image height", image.getHeight());
+      var origURL = image.getLinkUrl();
+      if (!origURL) {
+        return -4;
+      }
+      debugLog("Original URL from image", origURL);
+      var worked = 1;
+      var failure = 1;
+      for (; worked <= capableDerenderers; ++worked) {
+        //[3,"https://latex.codecogs.com/png.latex?","http://www.codecogs.com/eqnedit.php?latex=","%5Cinline%20", "", "Codecogs"]
+        renderer = getRenderer(worked)[2].split("FILENAME"); //list of possibly more than one string
+        for (var I = 0; I < renderer.length; ++I) {
+          if (origURL.indexOf(renderer[I]) > -1) {
+            debugLog("Changing: " + origURL + " by removing " + renderer[I]);
+            origURL = origURL.substring(origURL.indexOf(renderer[I])).split(renderer[I]).join(""); //removes prefix
+            debugLog("Next check: " + origURL + " for " + renderer[I + 1]);
+          } else break;
+        }
+      }
+      var last2 = origURL.slice(-2);
+      var delimtype = 0;
+      if (last2.length > 1 && (last2.charAt(0) == "%" || last2.charAt(0) == "#") && last2.charAt(1) >= "0" && last2.charAt(1) <= "9") {
+        //rendered with updated renderer
+        debugLog("Passed: " + last2);
+        delimtype = last2.charAt(1) - "0";
+        origURL = origURL.slice(0, -2);
+        delim = getDelimiters(getNumDelimiters(delimtype));
+      }
+      var origEq = deEncode(origURL);
+      //       if(origURL.indexOf("codecogs")>-1)//codecogs                         // bad: url hardcoded location
+      //          origEq = deEncode(origURL).substring(42);
+      //       else if(origURL.indexOf("texrendr")>-1)
+      //          origEq = deEncode(origURL).substring(29);
+      //       else return -3;
+      debugLog("Undid: " + origEq);
+      if (origEq.length <= 0) {
+        console.log("Empty equation derender.");
+        return -3;
+      }
+      cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+      element.getChild(position + 1).removeFromParent();
+      return 1;
+    } else {
+      return -2;
+    }
+  } else {
+    return -1;
+  }
+  return 0;
+}

--- a/test/Sidebar.html
+++ b/test/Sidebar.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <base target="_top" />
+    <meta charset="utf-8" />
+    <title>Auto-Latex Equations</title>
+    <!-- Google Analytics -->
+    <script>
+      //    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      //    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      //    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      //    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      //
+      //    ga('create', 'UA-XXXXX-Y', 'auto');
+      //    ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->
+
+    <meta name="description" content="Auto-Latex Equations - a Google Docs add-on to beautifully render math." />
+    <!-- <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no"> -->
+    <meta name="copyright" content="Aayush Gupta of Auto-Latex Equations. Contact me at autolatex@gmail.com." />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- <meta name="apple-mobile-web-app-capable" content="yes"> -->
+    <!-- <meta name="apple-mobile-web-app-status-bar-style" content="black"> -->
+    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+    <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons.css" />
+  </head>
+  <body>
+    <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css" />
+    <!--  The CSS package above applies Google styling to buttons and other elements. -->
+
+    <?!= HtmlService.createHtmlOutputFromFile('ALEStylesheet').getContent(); ?>
+
+    <div class="sidebar branding-below">
+      <form>
+        <div class="text" id="instructions">
+          <p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in $$ ... $$.</p>
+        </div>
+        <div class="text" id="example">
+          <p>For example, $$3^{4^5} + \frac{1}{2}$$ would be a valid equation. Try using this sample to render your first equation!<br /></p>
+        </div>
+
+        <div class="block form-group">
+          <label id="select_size">Select Size:</label>
+          <select id="size" name="size">
+            <option value="smart" selected>Automatic</option>
+            <option value="inline">Inline</option>
+            <option value="med">Font Size 24</option>
+            <option value="low">Font Size 12</option>
+          </select>
+        </div>
+
+        <a href="#" id="advanced">Show Advanced Settings</a>
+        <div id="divDelimiters" style="display: none">
+          <!-- style="display: inline-block;" or just style="display: block;" -->
+          <label id="select_size">Select Delimiter Style:<br /></label>
+          <select id="delimit" name="delimit">
+            <option value="$$" selected>$$ ... $$</option>
+            <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
+            <option value="\[">\[ ... \]</option>
+            <!--<option value = '$'>$ ... $</option>-->
+          </select>
+        </div>
+
+        <div style="line-height: 90%"><br /></div>
+
+        <div class="block" id="button-bar">
+          <div id="button-container" class="button-container">
+            <div id="render" class="button-row">
+              <button id="insert-text" class="action button-in-row1">Render Equations</button>
+              <button id="edit-text" class="button-in-row1">De-render Equation</button>
+            </div>
+            <div id="derenderall" class="button-row">
+              <button id="undo-all" class="create button-in-row2">De-render All Equations</button>
+              <!-- style ="width: 100%; margin: 4px 0 0 0; top: 10; right: 0;" -->
+            </div>
+          </div>
+        </div>
+        <div>
+          <span id="loading" style="font-weight: bold">Status: Idle</span>
+        </div>
+
+        <div>
+          <label id="tips">
+            <br />
+            <b>Tips:</b> <br />
+            • Place your cursor right before the equation and click "De-render Equation" to convert back to code. <br />
+            • Use shift+enter instead of enter for newlines in multi-line equations. Shift+enter auto-converts to \\.
+            <!-- <br> • Click the sidebar and press ctrl+q to derender all equations. (beta) -->
+            <br />
+            • 'Automatic' size matches the typed font size. <br />
+            • 'Inline' size compresses your equation height.
+          </label>
+          <div class="credit_images">
+            <a href="https://www.patreon.com/autolatex?source=docs" target="_blank">
+              <img src="https://i.ibb.co/d2pJpb3/Donate-Button.png" width="100" height="34" alt="Donate" />
+            </a>
+          </div>
+          <label id="More">
+            <b>More:</b> <br />
+            • <b>We have <a href="https://www.redbubble.com/shop/ap/140480196" target="_blank">merch now</a>! Buy shirts, pillows, mugs, and more for your math-loving friends and students.</b><br />
+            • Check out Auto-LaTeX in your Slides presentations!<br />
+            • Check out the latest <a href="https://sites.google.com/site/autolatexequations/" target="_blank">2022 Update Notes</a>. <br />
+            • Find a full list of commands at <a href="http://www.codecogs.com/eqnedit.php" target="_blank">CodeCogs</a>. <br />
+            • Problems? Check the <a href="https://www.autolatex.com/faq" target="_blank">FAQ</a>, email
+            <a href="mailto:autolatex@gmail.com" target="_blank">autolatex@gmail.com</a>, or check updates on
+            <a href="https://www.facebook.com/autolatex/" target="_blank">facebook</a>. <br />
+            • I'd love a
+            <a href="https://workspace.google.com/marketplace/app/autolatex_equations/850293439076?hl=en&pann=docs_addon_widget&ref=sidebar_review" target="_blank"
+              >5 star review here</a
+            >! <br />
+            • Please <a href="https://www.patreon.com/autolatex?source=docs" target="_blank">donate</a> on Patreon to help keep this updated! <br />
+            • I recently co-built
+            <a href="https://lipoker.io?ref=ale" target="_blank">lipoker.io</a>, the first free videochat poker site for friends, without signups or downloads. Think of it as the
+            Auto-LaTeX of poker -- no scams, and beautifully functional. Try it for your next social or game night! <br />
+          </label>
+        </div>
+      </form>
+      <div class="credit_images">
+        <img alt="CodeCogs logo" class="logo1" src="https://www.codecogs.com/images/poweredbycc.gif" />
+        <img alt="TexRendr logo" class="logo2" src="https://i.imgur.com/2pOfX3H.png" />
+      </div>
+      <!--<iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Fwww.facebook.com%2Fautolatex%2F&width=185&layout=button_count&action=like&size=small&show_faces=false&share=false&height=46&appId" width="250" height="46" style="border:none;overflow:hidden;float:center" scrolling="no" frameborder="0" allowTransparency="true"></iframe>-->
+    </div>
+
+    <div class="sidebar bottom" style="text-align: center; bottom: 4px; display: table-cell; vertical-align: bottom; position: fixed">
+      <!--<a href="http://autolatex.com/faq" class="small center" target="_blank">Help</a>-->
+    </div>
+    <script type="text/javascript" src="/nhpup_1.1.js"></script>
+    <?!= HtmlService.createHtmlOutputFromFile('SidebarJS').getContent(); ?>
+  </body>
+</html>

--- a/test/appsscript.json
+++ b/test/appsscript.json
@@ -1,0 +1,14 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Analytics",
+        "serviceId": "analytics",
+        "version": "v3"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -42,9 +42,9 @@ declare namespace AutoLatexCommon {
          */
         reEncode(equation: string, app: IntegratedApp): string;
 
-        renderEquation(equationOriginal: string, renderOptions: RenderOptions): {equation: string, renderer: Renderer, rendererType: string, resp: GoogleAppsScript.URL_Fetch.HTTPResponse, worked: number};
+        renderEquation(equationOriginal: string, renderOptions: RenderOptions): RenderEquationResult;
 
-        renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): {equation: string, renderer: Renderer, rendererType: string, resp: GoogleAppsScript.URL_Fetch.HTTPResponse, worked: number};
+        renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): RenderEquationResult;
 
         reportDeltaTime(line?: number, forcePrint?: string): number;
 
@@ -145,6 +145,10 @@ declare namespace AutoLatexCommon {
      */
     export interface RenderOptions {
 
+        allowedServerFamilies?: string[];
+
+        autoFallbackToClient?: boolean;
+
         b: number;
 
         clientRender: boolean;
@@ -160,6 +164,22 @@ declare namespace AutoLatexCommon {
         r: number;
 
         size: number;
+
+    }
+
+    export interface RenderEquationResult {
+
+        authorizationError?: boolean;
+
+        equation: string;
+
+        renderer: Renderer | null;
+
+        rendererType: string;
+
+        resp: GoogleAppsScript.URL_Fetch.HTTPResponse | null;
+
+        worked: number;
 
     }
 

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -111,6 +111,21 @@ declare namespace AutoLatexCommon {
 
     }
 
+    /**
+     * Per-equation failure info surfaced from server-side rendering to the sidebar.
+     * Used by the sidebar to show users *which* equation broke and *why*, instead of a
+     * generic catch-all error.
+     */
+    export interface EquationFailureDetail {
+
+        reason: string;
+
+        snippet: string;
+
+        hint: string;
+
+    }
+
     export interface IntegratedApp {
 
         newlineCharacter: string;

--- a/types/docs-types/index.d.ts
+++ b/types/docs-types/index.d.ts
@@ -35,6 +35,8 @@ declare namespace google {
 
             AllRenderersFailed,
 
+            AuthorizationFailed,
+
             ClientRender,
 
             EmptyEquation,

--- a/types/docs-types/index.d.ts
+++ b/types/docs-types/index.d.ts
@@ -12,6 +12,8 @@ declare namespace google {
 
             clientRenderComplete(equations: {options: AutoLatexCommon.ClientRenderOptions, renderedEquationB64: string}[]): void //intrinsic;
 
+            clientRenderFailed(equations: {options: AutoLatexCommon.ClientRenderOptions}[]): void //intrinsic;
+
             editEquations(sizeRaw: string, delimiter: string, renderer: string): void //reference;
 
             getKey(): void //intrinsic;
@@ -36,6 +38,8 @@ declare namespace google {
             ClientRender,
 
             EmptyEquation,
+
+            MultiElementEquation,
 
             NoDocument,
 


### PR DESCRIPTION
## Summary
- **Auto mode renderer fallback**: Codecogs (batched, server-side) → MathJax (parallel, client-side) → Texrendr/Sciweavers (server fallback)
- **Batched Codecogs**: All equations processed in one server call before falling back
- **Parallel MathJax**: Failed equations rendered with `Promise.all`-style concurrency (limit of 4) to avoid freezing the browser
- **Server fallback**: If MathJax fails, `clientRenderFailed` tries Texrendr/Sciweavers
- **Bug fix**: Slides `findPos` infinite loop when a renderer fails (text unchanged, same equation re-found)
- **UI**: MathJax beta option in renderer dropdown, new delimiter options, improved permissions error messaging

## Test plan
- [ ] Render equations in Docs with auto mode — verify Codecogs renders work as before
- [ ] Render equations in Slides with auto mode — verify batch Codecogs processing
- [ ] Test with a Codecogs-unsupported equation (e.g. very long) — verify MathJax fallback kicks in
- [ ] Test with MathJax failure scenario — verify Texrendr/Sciweavers fallback
- [ ] Test with many equations (20+) — verify no browser freeze from MathJax parallelism
- [ ] Test explicit MathJax renderer selection still works
- [ ] Test explicit Codecogs/Texrendr/Sciweavers selection still works
- [ ] Verify de-rendering works for equations rendered by each renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)