### PR TITLE
Use MathJax for default equation rendering

### DIFF
--- a/BuildSidebarJS.js
+++ b/BuildSidebarJS.js
@@ -7,8 +7,8 @@ const execPromise = promisify(exec);
 function getMathJaxSetup() {
   return `
 window.MathJax = {
-  loader: { load: ['tex-svg', '[tex]/color'] },
-  tex: { packages: { '[+]': ['color'] } },
+  loader: { load: ['tex-svg', '[tex]/color', '[tex]/textmacros'] },
+  tex: { packages: { '[+]': ['color', 'textmacros'] } },
   svg: {
     fontCache: 'none'
   },
@@ -35,7 +35,7 @@ ${sidebarJS}</script>${mathJaxScript}`;
 }
 
 async function compileTS() {
-  await execPromise("npx tsc --preserveConstEnums Sidebar.ts -t es2020 --lib es2020,dom --skipLibCheck");
+  await execPromise("npx tsc --preserveConstEnums Sidebar.ts -t es2020 --lib es2020,dom --types google-apps-script,jquery --skipLibCheck");
 }
 
 async function buildSidebarJS() {

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -170,9 +170,10 @@ function renderEquationWithCompatibility(equationOriginal: string, renderOptions
  */
 function replaceEquations(sizeRaw: string, delimiter: string, renderer: string = "auto") {
   const quality = 900;
-  const clientRender = renderer === "mathjax";
-  // REASON: In auto mode, try Codecogs server-side first, then MathJax on client, then Texrendr/Sciweavers.
-  const autoFallbackToClient = renderer === "auto";
+  // REASON: Default auto rendering uses MathJax in the sidebar. This avoids sending
+  // equation contents to legacy external renderer APIs such as Codecogs/Texrendr.
+  const clientRender = renderer === "mathjax" || renderer === "auto";
+  const autoFallbackToClient = false;
   if (clientRender) {
     console.log("MathJax render requested.", JSON.stringify({ sizeRaw, delimiter }));
   }

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -238,9 +238,16 @@ async function blobToB64(blob: Blob) {
   return dataUrl.substring(dataUrl.indexOf(",") + 1); // strip dataurl header
 }
 
+function hasNonAsciiText(value: string) {
+  return value.split("").some(char => char.charCodeAt(0) > 0x7F);
+}
+
 async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRenderOptions) {
+  const equationForMathJax = renderOptions.equation
+    .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
   // apply RGB coloring + newline becomes \\
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + renderOptions.equation.replace(/\n|\r|\r\n/g, "\\\\");
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
   
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
     throw new Error("MathJax is still loading. Please try again in a moment.");
@@ -482,33 +489,65 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
 
     // we're not done yet - these equations need to be rendered on the client
     const equationsToRender = clientEquations || [];
-    mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async c => ({ options: c, renderedEquationB64: await renderMathJaxEquation(c).then(b => blobToB64(b)) }))
-      .then(rendered => {
+    mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async c => {
+      try {
+        return {
+          ok: true as const,
+          rendered: {
+            options: c,
+            renderedEquationB64: await renderMathJaxEquation(c).then(b => blobToB64(b))
+          }
+        };
+      } catch (err) {
+        reportMathJaxClientError("clientRenderEquation", err, {
+          equation: c.equation,
+          equationLength: c.equation.length
+        });
+        return {
+          ok: false as const,
+          options: c
+        };
+      }
+    })
+      .then(results => {
         if (isStaleSidebarAction(actionId)) {
           return;
         }
-        google.script.run
-          .withSuccessHandler((result, userObject) => successHandler(result, userObject, actionId))
-          .withFailureHandler((msg, userObject) => errorHandler(msg, userObject, actionId))
-          .withUserObject(element)
-          .clientRenderComplete(rendered);
+        const rendered = results
+          .filter(result => result.ok)
+          .map(result => result.rendered);
+        const failed = results
+          .filter(result => !result.ok)
+          .map(result => ({ options: result.options }));
+
+        if (rendered.length > 0) {
+          google.script.run
+            .withSuccessHandler((result: ReplaceEquationsResult) => {
+              if (isStaleSidebarAction(actionId)) {
+                return;
+              }
+              if (failed.length > 0) {
+                errorHandler(new Error(`MathJax failed to render ${failed.length} equation(s).`), element, actionId);
+                return;
+              }
+              successHandler(result, element, actionId);
+            })
+            .withFailureHandler((msg, userObject) => errorHandler(msg, userObject, actionId))
+            .withUserObject(element)
+            .clientRenderComplete(rendered);
+          return;
+        }
+
+        if (failed.length > 0) {
+          errorHandler(new Error(`MathJax failed to render ${failed.length} equation(s).`), element, actionId);
+          return;
+        }
+
+        errorHandler(new Error("MathJax did not render any equations."), element, actionId);
       })
       .catch(err => {
         reportMathJaxClientError("clientRenderBatch", err, { equationCount: equationsToRender.length });
-        // REASON: In auto mode, if MathJax fails, try remaining server renderers (Texrendr/Sciweavers)
-        // instead of showing an error immediately.
-        if (getCurrentSettings().renderer === "auto") {
-          if (isStaleSidebarAction(actionId)) {
-            return;
-          }
-          google.script.run
-            .withSuccessHandler((result, userObject) => successHandler(result, userObject, actionId))
-            .withFailureHandler((msg, userObject) => errorHandler(msg, userObject, actionId))
-            .withUserObject(element)
-            .clientRenderFailed(equationsToRender.map(c => ({ options: c })));
-        } else {
-          errorHandler(err, element, actionId);
-        }
+        errorHandler(err, element, actionId);
       });
   } else {
     const roundSuccessCount = successCount;

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -148,9 +148,10 @@ function isTableCell(element: PageElement): element is GoogleAppsScript.Slides.T
  */
 function replaceEquations(sizeRaw: string, delimiter: string, renderer: string = "auto") {
   const quality = 900;
-  const clientRender = renderer === "mathjax";
-  // REASON: In auto mode, try Codecogs server-side first, then MathJax on client, then Texrendr/Sciweavers.
-  const autoFallback = renderer === "auto";
+  // REASON: Default auto rendering uses MathJax in the sidebar. This avoids sending
+  // equation contents to legacy external renderer APIs such as Codecogs/Texrendr.
+  const clientRender = renderer === "mathjax" || renderer === "auto";
+  const autoFallback = false;
   let size = Common.getSize(sizeRaw);
   let isInline = false;
   if (size < 0) {

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -91,8 +91,15 @@ async function blobToB64(blob: Blob) {
   return dataUrl.substring(dataUrl.indexOf(",") + 1);
 }
 
+function hasNonAsciiText(value: string) {
+  return value.split("").some(char => char.charCodeAt(0) > 0x7F);
+}
+
 async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + renderOptions.equation.replace(/\n|\r|\r\n/g, "\\\\");
+  const equationForMathJax = renderOptions.equation
+    .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
 
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
     throw new Error("MathJax is still loading. Please try again in a moment.");
@@ -335,32 +342,58 @@ function insertText(){
       // REASON: In auto mode, count any server-side successes (Codecogs) in the total.
       mathJaxRenderedCount += result.successCount;
 
-      // REASON: Render ALL equations with concurrency limit to avoid freezing the browser.
-      mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, eq =>
-        renderMathJaxEquation(eq)
-          .then(blob => blobToB64(blob))
-          .then(b64 => ({ options: eq, renderedEquationB64: b64 }))
-      )
-        .then(rendered => {
+      // REASON: Render equations independently. A single MathJax failure should not force
+      // the whole batch through legacy server renderers that cannot preserve Unicode text.
+      mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async eq => {
+        try {
+          return {
+            ok: true as const,
+            rendered: {
+              options: eq,
+              renderedEquationB64: await renderMathJaxEquation(eq).then(blob => blobToB64(blob))
+            }
+          };
+        } catch (error) {
+          console.error("MathJax equation render failed.", error, eq.equation);
+          return {
+            ok: false as const,
+            options: eq
+          };
+        }
+      })
+        .then(results => {
+          const rendered = results
+            .filter(result => result.ok)
+            .map(result => result.rendered);
+          const failed = results
+            .filter(result => !result.ok)
+            .map(result => ({ options: result.options }));
           const scriptRun = google.script.run as any;
-          scriptRun
-            .withSuccessHandler((response: SlidesClientEquationRenderResult, userObject: HTMLButtonElement) => handleMathJaxResponse(response, userObject))
-            .withFailureHandler((msg: unknown, userObject: HTMLButtonElement) => handleFailure(msg, userObject))
-            .withUserObject(element)
-            .clientRenderComplete(rendered);
-        })
-        .catch(error => {
-          // REASON: In auto mode, if MathJax fails, try remaining server renderers (Texrendr/Sciweavers)
-          if (renderer === "auto") {
-            const scriptRun = google.script.run as any;
+
+          if (rendered.length > 0) {
             scriptRun
-              .withSuccessHandler((response: SlidesClientEquationRenderResult, userObject: HTMLButtonElement) => handleMathJaxResponse(response, userObject))
+              .withSuccessHandler((response: SlidesClientEquationRenderResult, userObject: HTMLButtonElement) => {
+                if (failed.length > 0) {
+                  handleFailure(new Error(`MathJax failed to render ${failed.length} equation(s).`), element);
+                  return;
+                }
+                handleMathJaxResponse(response, userObject);
+              })
               .withFailureHandler((msg: unknown, userObject: HTMLButtonElement) => handleFailure(msg, userObject))
               .withUserObject(element)
-              .clientRenderFailed(equationsToRender.map(eq => ({ options: eq })));
-          } else {
-            handleFailure(error, element);
+              .clientRenderComplete(rendered);
+            return;
           }
+
+          if (failed.length > 0) {
+            handleFailure(new Error(`MathJax failed to render ${failed.length} equation(s).`), element);
+            return;
+          }
+
+          handleFailure(new Error("MathJax did not render any equations."), element);
+        })
+        .catch(error => {
+          handleFailure(error, element);
         });
       return;
     }


### PR DESCRIPTION
## Summary
- make the default auto renderer use the existing MathJax sidebar rendering path instead of legacy external renderer APIs
- load MathJax text macros so text-mode content such as Chinese text in \\mbox/\\text can render correctly
- render MathJax batches per equation so one failure does not send the whole batch through legacy server renderers
- apply the same default behavior to Docs and Slides

## Validation
- Verified locally that MathJax generates SVG containing CJK text without errors for the issue examples.
- Verified in a Google Docs test Apps Script project that Chinese formulas render as readable text.
- Ran TypeScript checks for Docs and Slides.
- Ran Docs and Slides sidebar builds.

Fixes #25