### PR TITLE
v83: pasted-LaTeX newline handling, multi-line fix, damaged-hline repair, long-URL guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Workspace/Sheets.js
 .env
 .env.*
 !.env.example
+SidebarMathJaxShared.js

--- a/BuildSidebarJS.js
+++ b/BuildSidebarJS.js
@@ -55,8 +55,9 @@ window.MathJax = {
 `;
 }
 
-function wrapJS(sidebarJS, includeMathJax) {
+function wrapJS(sidebarJS, includeMathJax, sharedJS) {
   const mathJaxSetup = includeMathJax ? getMathJaxSetup() : "";
+  const sharedBlock = includeMathJax && sharedJS ? `\n${sharedJS}` : "";
   // REASON: crossorigin="anonymous" makes the browser surface real error
   // details (message/filename/lineno/stack) in window.onerror for this
   // cross-origin script. Without it, every MathJax failure inside the sandboxed
@@ -69,7 +70,7 @@ function wrapJS(sidebarJS, includeMathJax) {
 
   return `<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script>
-${mathJaxSetup}
+${mathJaxSetup}${sharedBlock}
 ${sidebarJS}</script>${mathJaxScript}`;
 }
 
@@ -77,14 +78,28 @@ async function compileTS() {
   await execPromise("npx tsc --preserveConstEnums Sidebar.ts -t es2020 --lib es2020,dom --types google-apps-script,jquery --skipLibCheck");
 }
 
+// REASON: the MathJax equation preprocessing (depth-aware newlines, hline repair,
+// gathered wrap) must behave identically in the Docs and Slides sidebars. It lives
+// once in ../SidebarMathJaxShared.ts and is compiled + injected here rather than
+// copy-pasted into each Sidebar.ts.
+async function compileSharedTS() {
+  await execPromise("npx tsc --preserveConstEnums ../SidebarMathJaxShared.ts -t es2020 --lib es2020,dom --skipLibCheck");
+}
+
 async function buildSidebarJS() {
   await compileTS();
-  
+
   const sidebarJS = fs.readFileSync("Sidebar.js", "utf8");
   const sidebarHTML = fs.readFileSync("Sidebar.html", "utf8");
   const includeMathJax = sidebarHTML.includes("data-mathjax-enabled");
 
-  const wrapped = wrapJS(sidebarJS, includeMathJax);
+  let sharedJS = "";
+  if (includeMathJax) {
+    await compileSharedTS();
+    sharedJS = fs.readFileSync("../SidebarMathJaxShared.js", "utf8");
+  }
+
+  const wrapped = wrapJS(sidebarJS, includeMathJax, sharedJS);
 
   // write out
   fs.writeFileSync("SidebarJS.html", wrapped);

--- a/Common/Code.js
+++ b/Common/Code.js
@@ -409,6 +409,14 @@ function renderEquation(equationOriginal, renderOptionsOrQuality, legacyDelim, l
             debugLog("Cached equation: " + renderer[2] + renderer[6] + equation);
             reportDeltaTime(453);
             debugLog("Fetching ", renderer[1], " and ", renderer[2] + renderer[6] + equation);
+            // REASON: GET-based renderers 400 (Codecogs) or hang on very long URLs, and the
+            // sidebar could only guess "the equation was too long". Skip the fetch with an
+            // explicit error so the log states the real cause (with the equation, via the
+            // catch below) and the next renderer is tried. 8000 chars is beyond every
+            // observed successful render but under the point where Codecogs starts 400ing.
+            if (renderer[1].length > 8000) {
+                throw new Error("Equation URL too long for " + rendererType + " (" + renderer[1].length + " chars > 8000)");
+            }
             var _createFileInCache = UrlFetchApp.fetch(renderer[2] + renderer[6] + equation);
             // simulates putting text into text renderer => creates link for cached image which is accessed later
             // needed for codecogs to generate equation properly, need to figure out which other renderers need this. to test, use align* equations.

--- a/Common/Code.js
+++ b/Common/Code.js
@@ -273,6 +273,21 @@ function getClientEquation(equationOriginal, app) {
         .split("%5C%5C%5C%5C%20").join(app.newlineCharacter)
         .split("%5C%5C%5C%5C").join("%5C%5C"));
 }
+// REASON: equation URLs written before the encodeURIComponent migration were encoded
+// with escape(), whose %uXXXX (non-Latin-1) and lone Latin-1 %XX byte sequences
+// decodeURIComponent rejects with "URIError: URI malformed" — making every ancient
+// image containing a non-ASCII character underenderable. unescape() still decodes
+// both legacy forms, so fall back to it on failure and recover the equation. Never
+// try unescape() first: it mangles valid modern UTF-8 pairs (%C3%A9 -> "Ã©").
+function decodeEquationComponent(encoded) {
+    try {
+        return decodeURIComponent(encoded);
+    }
+    catch (err) {
+        console.log("decodeEquationComponent: legacy escape()-era encoding; decoding with unescape().", String(err));
+        return unescape(encoded);
+    }
+}
 /**
  * returns the deencoded equation as a string.
  */
@@ -280,7 +295,7 @@ function deEncode(equation, app) {
     reportDeltaTime(269);
     debugLog("Equation to derender", equation);
     // First decode pass - handles newlines, #, and +
-    var decoded = decodeURIComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0, app));
+    var decoded = decodeEquationComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0, app));
     debugLog("First decode pass", decoded);
     reportDeltaTime(274);
     // Second pass - handles quotes and other characters

--- a/Common/Code.js
+++ b/Common/Code.js
@@ -256,6 +256,24 @@ function reEncode(equation, app) {
     return getCustomEncode(encodeURIComponent(equation), 0, 0, app); //escape deprecated
 }
 /**
+ * Decode a reEncoded equation for the client-side (MathJax) renderer.
+ *
+ * REASON: reEncode turns each in-equation newline into an encoded four-backslash
+ * marker ("%5C%5C%5C%5C%20"). Restore it to the app's literal newline character
+ * (Docs \r, Slides \v, Sheets \n) so the sidebar can decide per-position whether
+ * a newline is a row break or cosmetic paste formatting, and collapse legacy
+ * doubled row breaks in ENCODED space exactly like the Codecogs path — a
+ * three-backslash run (e.g. "\\\hline") encodes to three %5C tokens and cannot
+ * false-match. Never collapse pairs in decoded space: that halving corrupted
+ * tables and align/matrix row breaks (fixed 2026-07).
+ * @public
+ */
+function getClientEquation(equationOriginal, app) {
+    return decodeURIComponent(equationOriginal
+        .split("%5C%5C%5C%5C%20").join(app.newlineCharacter)
+        .split("%5C%5C%5C%5C").join("%5C%5C"));
+}
+/**
  * returns the deencoded equation as a string.
  */
 function deEncode(equation, app) {

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -563,6 +563,15 @@ function renderEquation(
       reportDeltaTime(453);
       debugLog("Fetching ", renderer[1], " and ", renderer[2] + renderer[6] + equation);
 
+      // REASON: GET-based renderers 400 (Codecogs) or hang on very long URLs, and the
+      // sidebar could only guess "the equation was too long". Skip the fetch with an
+      // explicit error so the log states the real cause (with the equation, via the
+      // catch below) and the next renderer is tried. 8000 chars is beyond every
+      // observed successful render but under the point where Codecogs starts 400ing.
+      if (renderer[1].length > 8000) {
+        throw new Error("Equation URL too long for " + rendererType + " (" + renderer[1].length + " chars > 8000)");
+      }
+
       const _createFileInCache = UrlFetchApp.fetch(renderer[2] + renderer[6] + equation);
       // simulates putting text into text renderer => creates link for cached image which is accessed later
       // needed for codecogs to generate equation properly, need to figure out which other renderers need this. to test, use align* equations.

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -387,6 +387,27 @@ function reEncode(equation: string, app: IntegratedApp) {
 }
 
 /**
+ * Decode a reEncoded equation for the client-side (MathJax) renderer.
+ *
+ * REASON: reEncode turns each in-equation newline into an encoded four-backslash
+ * marker ("%5C%5C%5C%5C%20"). Restore it to the app's literal newline character
+ * (Docs \r, Slides \v, Sheets \n) so the sidebar can decide per-position whether
+ * a newline is a row break or cosmetic paste formatting, and collapse legacy
+ * doubled row breaks in ENCODED space exactly like the Codecogs path — a
+ * three-backslash run (e.g. "\\\hline") encodes to three %5C tokens and cannot
+ * false-match. Never collapse pairs in decoded space: that halving corrupted
+ * tables and align/matrix row breaks (fixed 2026-07).
+ * @public
+ */
+function getClientEquation(equationOriginal: string, app: IntegratedApp) {
+  return decodeURIComponent(
+    equationOriginal
+      .split("%5C%5C%5C%5C%20").join(app.newlineCharacter)
+      .split("%5C%5C%5C%5C").join("%5C%5C")
+  );
+}
+
+/**
  * returns the deencoded equation as a string.
  */
 function deEncode(equation: string, app: IntegratedApp) {

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -414,6 +414,21 @@ function getClientEquation(equationOriginal: string, app: IntegratedApp) {
   );
 }
 
+// REASON: equation URLs written before the encodeURIComponent migration were encoded
+// with escape(), whose %uXXXX (non-Latin-1) and lone Latin-1 %XX byte sequences
+// decodeURIComponent rejects with "URIError: URI malformed" — making every ancient
+// image containing a non-ASCII character underenderable. unescape() still decodes
+// both legacy forms, so fall back to it on failure and recover the equation. Never
+// try unescape() first: it mangles valid modern UTF-8 pairs (%C3%A9 -> "Ã©").
+function decodeEquationComponent(encoded: string) {
+  try {
+    return decodeURIComponent(encoded);
+  } catch (err) {
+    console.log("decodeEquationComponent: legacy escape()-era encoding; decoding with unescape().", String(err));
+    return unescape(encoded);
+  }
+}
+
 /**
  * returns the deencoded equation as a string.
  */
@@ -421,7 +436,7 @@ function deEncode(equation: string, app: IntegratedApp) {
   reportDeltaTime(269);
   debugLog("Equation to derender", equation);
   // First decode pass - handles newlines, #, and +
-  const decoded = decodeURIComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0, app));
+  const decoded = decodeEquationComponent(getCustomEncode(getFilenameEncode(equation, 1), 1, 0, app));
   debugLog("First decode pass", decoded);
   reportDeltaTime(274);
   // Second pass - handles quotes and other characters

--- a/Common/Code.ts
+++ b/Common/Code.ts
@@ -76,6 +76,13 @@ interface ClientRenderOptions extends CommonRenderOptions {
   rangeId: string;
   equation: string;
   equationLinkEncoded: string;
+  // REASON: equations inside highlighted (background-colored) text render as
+  // transparent PNGs, which show the white page through the highlight band.
+  // When the doc text carries a background color, it's sampled here so the
+  // client can bake it into the image. Absent -> transparent (unchanged).
+  bgR?: number;
+  bgG?: number;
+  bgB?: number;
 }
 
 /**

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -444,8 +444,12 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     Common.reportDeltaTime(195);
     var docBody = getBodyFromIndex(index);
     if (docBody == null) {
+        // REASON: an unrecognized section type means "nothing to scan here", not "the
+        // document failed to load". Returning NoDocument here aborted the whole render
+        // with a misleading auth error for any doc containing such a section (silently —
+        // this path logged nothing, which is why user reports were undiagnosable).
         return {
-            status: 5 /* DocsEquationRenderStatus.NoDocument */
+            status: 7 /* DocsEquationRenderStatus.NoStartDelimiter */
         };
     }
     var startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty, 2);
@@ -923,10 +927,19 @@ function getBodyFromIndex(index) {
     Common.assert(index < all, "index < all");
     var body = p.getChild(index);
     var type = body.getType();
-    if (type === DocumentApp.ElementType.BODY_SECTION || type === DocumentApp.ElementType.HEADER_SECTION || type === DocumentApp.ElementType.FOOTER_SECTION) {
+    // REASON: FOOTNOTE_SECTION included — academic docs commonly have footnotes, and
+    // before 2026-07 hitting one aborted the entire render with a misleading
+    // "conflicting authorizations" error (the section walker returned null and findPos
+    // mapped null to NoDocument). Footnote equations render fine: FootnoteSection
+    // supports findText/getImages, and placeImage already walks up to it.
+    if (type === DocumentApp.ElementType.BODY_SECTION ||
+        type === DocumentApp.ElementType.HEADER_SECTION ||
+        type === DocumentApp.ElementType.FOOTER_SECTION ||
+        type === DocumentApp.ElementType.FOOTNOTE_SECTION) {
         // handles alternating footers etc.
         return body;
     }
+    console.log("Skipping non-scannable document section", index, String(type));
     return null;
 }
 /**
@@ -938,7 +951,9 @@ function removeAll(defaultDelimRaw) {
     var defaultDelim = Common.getDelimiters(defaultDelimRaw);
     for (var index = 0; index < getDocsApp().getBody().getParent().getNumChildren(); index++) {
         var body = getBodyFromIndex(index);
-        var img = body === null || body === void 0 ? void 0 : body.getImages(); //places all InlineImages from the active document into the array img
+        // REASON: FootnoteSection has findText (so rendering works there) but no
+        // getImages; De-render All just skips footnote sections.
+        var img = body && "getImages" in body ? body.getImages() : undefined; //places all InlineImages from the active document into the array img
         for (var i = 0; i < ((img === null || img === void 0 ? void 0 : img.length) || 0); i++) {
             var image = img[i];
             var origURL = new String(image.getLinkUrl()).toString(); //becomes "null", not null, if no equation link

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -610,6 +610,7 @@ function getSize(size, defaultSize, rangeElement) {
 function clientRenderComplete(equations) {
     var mathjaxRenderer = Common.getRenderer(Common.rendererIds.MATHJAX);
     var c = 0;
+    var alreadyRenderedCount = 0;
     console.log("MathJax client render completion received equations:", equations.length);
     // Go backwards so that the named ranges for multiple equations in the same paragraph don't get removed
     equations.reverse();
@@ -627,6 +628,14 @@ function clientRenderComplete(equations) {
                 console.warn("MathJax client render range is empty:", equation.options.rangeId);
                 continue;
             }
+            // REASON: if the range element is no longer Text (most commonly it's already an
+            // INLINE_IMAGE from a double-click render or an overlapping batch), placeImage's
+            // asText() threw a locale-dependent cast error — thousands of ERROR lines/day for
+            // what is a benign "already done" state. Skip quietly instead.
+            if (rangeElements[0].getElement().getType() !== DocumentApp.ElementType.TEXT) {
+                alreadyRenderedCount++;
+                continue;
+            }
             var equationBlob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
             var result = placeImage(rangeElements[0], equationBlob, mathjaxRenderer, equation.options.equationLinkEncoded, equation.options.size, equation.options.delim);
             if (result.status === 8 /* DocsEquationRenderStatus.Success */) {
@@ -639,6 +648,9 @@ function clientRenderComplete(equations) {
         finally {
             namedRange === null || namedRange === void 0 ? void 0 : namedRange.remove();
         }
+    }
+    if (alreadyRenderedCount > 0) {
+        console.log("MathJax client render completion skipped already-rendered ranges:", alreadyRenderedCount);
     }
     return {
         lastStatus: 8 /* DocsEquationRenderStatus.Success */,
@@ -818,17 +830,46 @@ function findInsertableAncestor(element) {
     }
     return null;
 }
+// REASON: a doc with several unplaceable equations logged the same failure for every
+// equation on every retry (observed: one stuck user emitted ~2300 ERROR lines/day).
+// Log each distinct container type once per execution; the thrown error still carries
+// the message for the per-equation failure details.
+var reportedPlaceImageFailureTypes = new Set();
 function placeImage(startElement, renderedEquation, renderer, equation, size, delim) {
     // GET VARIABLES
     var textElement = startElement.getElement().asText();
-    var text = textElement.getText();
+    var startOffset = startElement.getStartOffset();
+    var endOffsetInclusive = startElement.getEndOffsetInclusive();
     var ancestor = findInsertableAncestor(textElement);
+    if (!ancestor) {
+        // REASON: prod logs show Text elements living DIRECTLY under a section
+        // (directParentType=BODY_SECTION) — no Paragraph wrapper, so no ancestor exposes
+        // insertInlineImage and rendering hard-failed for those docs. Sections do expose
+        // insertParagraph, so wrap the text in a fresh Paragraph at the same position and
+        // continue normally. The equations themselves are valid; only the container is odd.
+        var directParent = textElement.getParent();
+        var sectionLike = directParent;
+        if (directParent && typeof sectionLike.insertParagraph === "function" &&
+            typeof sectionLike.getChildIndex === "function" && typeof sectionLike.removeChild === "function") {
+            var idx = sectionLike.getChildIndex(textElement);
+            var wrapper = sectionLike.insertParagraph(idx, "");
+            var movedText = wrapper.appendText(textElement.getText());
+            sectionLike.removeChild(textElement);
+            textElement = movedText;
+            ancestor = { container: wrapper, directChild: movedText };
+            console.log("placeImage: wrapped section-level text in a paragraph to place the equation.");
+        }
+    }
     if (!ancestor) {
         var directParent = textElement.getParent();
         var parentType = directParent && typeof directParent.getType === "function" ? String(directParent.getType()) : "<unknown>";
-        console.error("placeImage: no ancestor within 6 levels supports insertInlineImage. directParentType=", parentType, " equation=", equation);
+        if (!reportedPlaceImageFailureTypes.has(parentType)) {
+            reportedPlaceImageFailureTypes.add(parentType);
+            console.error("placeImage: no ancestor within 6 levels supports insertInlineImage. directParentType=", parentType, " equation=", equation);
+        }
         throw new Error("Cannot place image: equation is in an unsupported container (direct parent type ".concat(parentType, "). Inline images can't be inserted here."));
     }
+    var text = textElement.getText();
     // REASON: TypeScript's union of insertable containers (Body, TableCell, FootnoteSection,
     // Paragraph, ListItem, ...) is wide; the methods we actually call (insertInlineImage,
     // insertText, getChild, getChildIndex) exist on all of them at runtime. Cast to the
@@ -837,12 +878,12 @@ function placeImage(startElement, renderedEquation, renderer, equation, size, de
     var paragraph = ancestor.container;
     var childIndex = paragraph.getChildIndex(ancestor.directChild); //gets index of found text (or its containing wrapper) in the insertable ancestor
     var textCopy = textElement.asText().copy();
-    var endLimit = startElement.getEndOffsetInclusive();
+    var endLimit = endOffsetInclusive;
     if (text.length - 1 < endLimit)
         endLimit = text.length - 1;
     textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
     Common.reportDeltaTime(522);
-    textElement.editAsText().deleteText(startElement.getStartOffset(), text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
+    textElement.editAsText().deleteText(startOffset, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
     Common.reportDeltaTime(526);
     // try inserting twice
     for (var tryNum = 1; tryNum <= 2; tryNum++) {
@@ -962,7 +1003,16 @@ function removeAll(defaultDelimRaw) {
             }
             // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
             // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-            var result = Common.derenderEquation(origURL, getDocsApp());
+            // REASON: same escape()-era %uXXXX guard as derenderInlineImage — one ancient
+            // image must not crash De-render All for the whole document.
+            var result = void 0;
+            try {
+                result = Common.derenderEquation(origURL, getDocsApp());
+            }
+            catch (err) {
+                console.error("removeAll: failed to decode equation URL; skipping image.", String(err), " url=", String(origURL).substring(0, 500));
+                continue;
+            }
             if (!result)
                 continue;
             var origEq = result.origEq, newDelim = result.delim;
@@ -995,7 +1045,18 @@ function derenderInlineImage(image, defaultDelim) {
     if (!origURL) {
         return 4 /* Common.DerenderResult.NullUrl */;
     }
-    var result = Common.derenderEquation(origURL, getDocsApp());
+    // REASON: images rendered in the escape()-encoding era carry %uXXXX sequences that
+    // decodeURIComponent rejects (URIError: URI malformed). Uncaught, one ancient image
+    // crashed the whole De-render run. Log WITH the URL so the offending encoding is
+    // visible, and skip just this image.
+    var result;
+    try {
+        result = Common.derenderEquation(origURL, getDocsApp());
+    }
+    catch (err) {
+        console.error("derenderInlineImage: failed to decode equation URL; skipping image.", String(err), " url=", String(origURL).substring(0, 500));
+        return 2 /* Common.DerenderResult.InvalidUrl */;
+    }
     if (!result)
         return 2 /* Common.DerenderResult.InvalidUrl */;
     var newDelim = result.delim, origEq = result.origEq;

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -673,8 +673,15 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     var colorHex = textElement.getForegroundColor(startElement.getStartOffset());
     // Docs can return null or malformed colors in some edge cases. Fall back to black.
     var _a = getRgbFromHex(colorHex), r = _a[0], g = _a[1], b = _a[2];
+    // REASON: users build dark documents by highlighting text with a dark background
+    // color; the transparent equation PNG then shows the white page through the
+    // highlight band, making light-colored equations invisible. Sample the text's
+    // background color so the client bakes it into the image. No highlight (null)
+    // keeps the image transparent, exactly as before.
+    var bgHex = textElement.getBackgroundColor(startElement.getStartOffset());
+    var bgColor = bgHex ? getRgbFromHex(bgHex) : null;
     // add color info to render options
-    var coloredRenderOptions = __assign(__assign({}, renderOptions), { r: r, g: g, b: b });
+    var coloredRenderOptions = __assign(__assign(__assign({}, renderOptions), { r: r, g: g, b: b }), (bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}));
     // REASON: Explicit MathJax and Automatic both render on the client first.
     // Automatic falls back to server renderers from the sidebar only if MathJax fails.
     if (renderOptions.clientRender || renderOptions.autoFallbackToClient) {
@@ -966,10 +973,80 @@ function removeAll(defaultDelimRaw) {
  * @param {string} sizeRaw     Sidebar-selected size.
  * @public
  */
+// Derender one equation image in place: insert the recovered LaTeX text at the
+// image's position in its parent and remove the image.
+function derenderInlineImage(image, defaultDelim) {
+    var origURL = image.getLinkUrl();
+    if (!origURL) {
+        return 4 /* Common.DerenderResult.NullUrl */;
+    }
+    var result = Common.derenderEquation(origURL, getDocsApp());
+    if (!result)
+        return 2 /* Common.DerenderResult.InvalidUrl */;
+    var newDelim = result.delim, origEq = result.origEq;
+    var delim = newDelim || defaultDelim;
+    if (origEq.length <= 0) {
+        console.log("Empty equation derender.");
+        return 1 /* Common.DerenderResult.EmptyEquation */;
+    }
+    var parent = image.getParent();
+    var imageIndex = parent.getChildIndex(image);
+    parent.insertText(imageIndex, delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+    image.removeFromParent();
+    return 5 /* Common.DerenderResult.Success */;
+}
+// Collect equation-candidate inline images from the user's selection, in document
+// order. Handles both a directly selected image and selections that span
+// paragraphs/list items containing images.
+function collectSelectedInlineImages(selection) {
+    var images = [];
+    for (var _i = 0, _a = selection.getRangeElements(); _i < _a.length; _i++) {
+        var rangeElement = _a[_i];
+        var el = rangeElement.getElement();
+        var elType = el.getType();
+        if (elType === DocumentApp.ElementType.INLINE_IMAGE) {
+            images.push(el.asInlineImage());
+        }
+        else if (elType === DocumentApp.ElementType.PARAGRAPH || elType === DocumentApp.ElementType.LIST_ITEM) {
+            var container = el;
+            for (var i = 0; i < container.getNumChildren(); i++) {
+                var child = container.getChild(i);
+                if (child.getType() === DocumentApp.ElementType.INLINE_IMAGE) {
+                    images.push(child.asInlineImage());
+                }
+            }
+        }
+    }
+    return images;
+}
 function editEquations(sizeRaw, delimiter, renderer) {
     if (renderer === void 0) { renderer = "auto"; }
     var defaultDelim = Common.getDelimiters(delimiter);
     Common.savePrefs(sizeRaw, delimiter, renderer);
+    // REASON: users naturally click/select the equation image itself and hit
+    // De-render; the cursor-only flow returned CursorNotFound for that (a selection
+    // means there is no cursor). Derender every equation image in the selection —
+    // in reverse document order so earlier removals can't shift later indices.
+    var selection = DocumentApp.getActiveDocument().getSelection();
+    if (selection) {
+        var images = collectSelectedInlineImages(selection);
+        if (images.length === 0) {
+            return 3 /* Common.DerenderResult.NonExistentElement */;
+        }
+        var successCount = 0;
+        var lastFailureResult = 2 /* Common.DerenderResult.InvalidUrl */;
+        for (var _i = 0, _a = images.reverse(); _i < _a.length; _i++) {
+            var image_1 = _a[_i];
+            var result = derenderInlineImage(image_1, defaultDelim);
+            if (result === 5 /* Common.DerenderResult.Success */) {
+                successCount++;
+            }
+            else {
+                lastFailureResult = result;
+            }
+        }
+        return successCount > 0 ? 5 /* Common.DerenderResult.Success */ : lastFailureResult;
+    }
     var cursor = DocumentApp.getActiveDocument().getCursor();
     if (!cursor) {
         return 0 /* Common.DerenderResult.CursorNotFound */;
@@ -1004,21 +1081,5 @@ function editEquations(sizeRaw, delimiter, renderer) {
     }
     var image = childAtCursor.asInlineImage();
     Common.debugLog("Image height", image.getHeight());
-    var origURL = image.getLinkUrl();
-    if (!origURL) {
-        return 4 /* Common.DerenderResult.NullUrl */;
-    }
-    Common.debugLog("Original URL from image", origURL);
-    var result = Common.derenderEquation(origURL, getDocsApp());
-    if (!result)
-        return 2 /* Common.DerenderResult.InvalidUrl */;
-    var newDelim = result.delim, origEq = result.origEq;
-    var delim = newDelim || defaultDelim;
-    if (origEq.length <= 0) {
-        console.log("Empty equation derender.");
-        return 1 /* Common.DerenderResult.EmptyEquation */;
-    }
-    cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
-    element.getChild(position + 1).removeFromParent();
-    return 5 /* Common.DerenderResult.Success */;
+    return derenderInlineImage(image, defaultDelim);
 }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -1046,7 +1046,7 @@ function editEquations(sizeRaw, delimiter, renderer) {
     if (selection) {
         var images = collectSelectedInlineImages(selection);
         if (images.length === 0) {
-            return 3 /* Common.DerenderResult.NonExistentElement */;
+            return { result: 3 /* Common.DerenderResult.NonExistentElement */, successCount: 0 };
         }
         var successCount = 0;
         var lastFailureResult = 2 /* Common.DerenderResult.InvalidUrl */;
@@ -1060,15 +1060,17 @@ function editEquations(sizeRaw, delimiter, renderer) {
                 lastFailureResult = result;
             }
         }
-        return successCount > 0 ? 5 /* Common.DerenderResult.Success */ : lastFailureResult;
+        return successCount > 0
+            ? { result: 5 /* Common.DerenderResult.Success */, successCount: successCount }
+            : { result: lastFailureResult, successCount: 0 };
     }
     var cursor = DocumentApp.getActiveDocument().getCursor();
     if (!cursor) {
-        return 0 /* Common.DerenderResult.CursorNotFound */;
+        return { result: 0 /* Common.DerenderResult.CursorNotFound */, successCount: 0 };
     }
     var elementRaw = cursor.getElement();
     if (!elementRaw) {
-        return 3 /* Common.DerenderResult.NonExistentElement */;
+        return { result: 3 /* Common.DerenderResult.NonExistentElement */, successCount: 0 };
     }
     // REASON: Cursor.getElement() can return any Element subtype (Table, TableOfContents,
     // FootnoteSection, etc.) - not just Paragraph/ListItem. The previous code did an unchecked
@@ -1078,13 +1080,13 @@ function editEquations(sizeRaw, delimiter, renderer) {
     var elementType = elementRaw.getType();
     if (elementType !== DocumentApp.ElementType.PARAGRAPH && elementType !== DocumentApp.ElementType.LIST_ITEM) {
         console.log("editEquations: cursor is in unsupported element type", elementType);
-        return 3 /* Common.DerenderResult.NonExistentElement */;
+        return { result: 3 /* Common.DerenderResult.NonExistentElement */, successCount: 0 };
     }
     var element = elementRaw;
     console.log("Valid cursor.");
     var position = cursor.getOffset(); //offset
     if (position >= element.getNumChildren()) {
-        return 0 /* Common.DerenderResult.CursorNotFound */;
+        return { result: 0 /* Common.DerenderResult.CursorNotFound */, successCount: 0 };
     }
     // REASON: getChild(position).asInlineImage() throws "TEXT can't be cast to INLINE_IMAGE"
     // when the user's cursor is on text instead of an equation image. Check the child type
@@ -1092,9 +1094,13 @@ function editEquations(sizeRaw, delimiter, renderer) {
     var childAtCursor = element.getChild(position);
     if (childAtCursor.getType() !== DocumentApp.ElementType.INLINE_IMAGE) {
         console.log("editEquations: child at cursor is not an inline image", childAtCursor.getType());
-        return 3 /* Common.DerenderResult.NonExistentElement */;
+        return { result: 3 /* Common.DerenderResult.NonExistentElement */, successCount: 0 };
     }
     var image = childAtCursor.asInlineImage();
     Common.debugLog("Image height", image.getHeight());
-    return derenderInlineImage(image, defaultDelim);
+    var cursorResult = derenderInlineImage(image, defaultDelim);
+    return {
+        result: cursorResult,
+        successCount: cursorResult === 5 /* Common.DerenderResult.Success */ ? 1 : 0
+    };
 }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -703,7 +703,14 @@ function buildClientRenderResponse(textElement, startElement, equationOriginal, 
     // silently merging align/matrix rows and degrading "\\\hline" -> "\\hline" ->
     // (after a derender round-trip) a bare "\hline", which MathJax rejects as
     // "Misplaced \hline".
-    var clientEquation = decodeURIComponent(equationOriginal.split("%5C%5C%5C%5C").join("%5C%5C"));
+    var clientEquation = decodeURIComponent(equationOriginal
+        // REASON: restore the reEncode newline marker to a literal \r (what the doc
+        // actually contained) instead of pre-converting to "\\". The client decides
+        // per-position whether a newline is a row break or cosmetic paste formatting
+        // (inside environments), and derender round-trips stay byte-identical.
+        .split("%5C%5C%5C%5C%20").join("%0D")
+        // legacy doubled row breaks, same collapse as the Codecogs path
+        .split("%5C%5C%5C%5C").join("%5C%5C"));
     var doc = DocumentApp.getActiveDocument();
     var range = doc.newRange()
         .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -703,14 +703,7 @@ function buildClientRenderResponse(textElement, startElement, equationOriginal, 
     // silently merging align/matrix rows and degrading "\\\hline" -> "\\hline" ->
     // (after a derender round-trip) a bare "\hline", which MathJax rejects as
     // "Misplaced \hline".
-    var clientEquation = decodeURIComponent(equationOriginal
-        // REASON: restore the reEncode newline marker to a literal \r (what the doc
-        // actually contained) instead of pre-converting to "\\". The client decides
-        // per-position whether a newline is a row break or cosmetic paste formatting
-        // (inside environments), and derender round-trips stay byte-identical.
-        .split("%5C%5C%5C%5C%20").join("%0D")
-        // legacy doubled row breaks, same collapse as the Codecogs path
-        .split("%5C%5C%5C%5C").join("%5C%5C"));
+    var clientEquation = Common.getClientEquation(equationOriginal, getDocsApp());
     var doc = DocumentApp.getActiveDocument();
     var range = doc.newRange()
         .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -838,16 +838,7 @@ function buildClientRenderResponse(
   // silently merging align/matrix rows and degrading "\\\hline" -> "\\hline" ->
   // (after a derender round-trip) a bare "\hline", which MathJax rejects as
   // "Misplaced \hline".
-  const clientEquation = decodeURIComponent(
-    equationOriginal
-      // REASON: restore the reEncode newline marker to a literal \r (what the doc
-      // actually contained) instead of pre-converting to "\\". The client decides
-      // per-position whether a newline is a row break or cosmetic paste formatting
-      // (inside environments), and derender round-trips stay byte-identical.
-      .split("%5C%5C%5C%5C%20").join("%0D")
-      // legacy doubled row breaks, same collapse as the Codecogs path
-      .split("%5C%5C%5C%5C").join("%5C%5C")
-  );
+  const clientEquation = Common.getClientEquation(equationOriginal, getDocsApp());
   const doc = DocumentApp.getActiveDocument();
   const range = doc.newRange()
     .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -399,7 +399,7 @@ function isSingleDollarDelimiter(rangeElement: GoogleAppsScript.Document.RangeEl
 // instead of `\]`, find none, and report "no equations found." For `$ ... $` the two are the
 // same regex so either index works; isSingleDollarDelimiter still filters out `$$` / `\$` cases.
 function findNextDelimiter(
-  docBody: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection,
+  docBody: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection | GoogleAppsScript.Document.FootnoteSection,
   renderOptions: AutoLatexCommon.RenderOptions,
   fromRange: GoogleAppsScript.Document.RangeElement | null = null,
   delimIdx: 2 | 3 = 2
@@ -439,7 +439,7 @@ function findNextDelimiter(
 // (the Enter-instead-of-Shift+Enter case) so we can auto-fix them.
 function getContainingTopLevelChild(
   element: GoogleAppsScript.Document.Element,
-  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection
+  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection | GoogleAppsScript.Document.FootnoteSection
 ): { topLevelChild: GoogleAppsScript.Document.Element, indexInBody: number } | null {
   let current: GoogleAppsScript.Document.Element | null = element;
   while (current != null) {
@@ -478,7 +478,7 @@ function getContainingTopLevelChild(
 // preserved because appendText only takes a string. Formatting is not the failure condition;
 // the paragraph break is.
 function tryAutoMergeMultiParagraphEquation(
-  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection,
+  body: GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection | GoogleAppsScript.Document.FootnoteSection,
   startParaIdx: number,
   endParaIdx: number
 ): { success: boolean, reason: string } {
@@ -545,8 +545,12 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
   Common.reportDeltaTime(195);
   const docBody = getBodyFromIndex(index);
   if (docBody == null) {
+    // REASON: an unrecognized section type means "nothing to scan here", not "the
+    // document failed to load". Returning NoDocument here aborted the whole render
+    // with a misleading auth error for any doc containing such a section (silently —
+    // this path logged nothing, which is why user reports were undiagnosable).
     return {
-      status: DocsEquationRenderStatus.NoDocument
+      status: DocsEquationRenderStatus.NoStartDelimiter
     };
   }
   const startElement = findNextDelimiter(docBody, renderOptions, prevFailedStartElemIfIsEmpty, 2);
@@ -1082,10 +1086,19 @@ function getBodyFromIndex(index: number) {
   Common.assert(index < all, "index < all");
   const body = p.getChild(index);
   const type = body.getType();
-  if (type === DocumentApp.ElementType.BODY_SECTION || type === DocumentApp.ElementType.HEADER_SECTION || type === DocumentApp.ElementType.FOOTER_SECTION) {
+  // REASON: FOOTNOTE_SECTION included — academic docs commonly have footnotes, and
+  // before 2026-07 hitting one aborted the entire render with a misleading
+  // "conflicting authorizations" error (the section walker returned null and findPos
+  // mapped null to NoDocument). Footnote equations render fine: FootnoteSection
+  // supports findText/getImages, and placeImage already walks up to it.
+  if (type === DocumentApp.ElementType.BODY_SECTION ||
+      type === DocumentApp.ElementType.HEADER_SECTION ||
+      type === DocumentApp.ElementType.FOOTER_SECTION ||
+      type === DocumentApp.ElementType.FOOTNOTE_SECTION) {
     // handles alternating footers etc.
     return body as GoogleAppsScript.Document.Body | GoogleAppsScript.Document.HeaderSection | GoogleAppsScript.Document.FooterSection;
   }
+  console.log("Skipping non-scannable document section", index, String(type));
   return null;
 }
 
@@ -1099,7 +1112,9 @@ function removeAll(defaultDelimRaw: string) {
   
   for (var index = 0; index < getDocsApp().getBody().getParent().getNumChildren(); index++) {
     const body = getBodyFromIndex(index);
-    const img = body?.getImages(); //places all InlineImages from the active document into the array img
+    // REASON: FootnoteSection has findText (so rendering works there) but no
+    // getImages; De-render All just skips footnote sections.
+    const img = body && "getImages" in body ? body.getImages() : undefined; //places all InlineImages from the active document into the array img
     for (let i = 0; i < (img?.length || 0); i++) {
       const image = img![i];
       let origURL = new String(image.getLinkUrl()).toString(); //becomes "null", not null, if no equation link

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -723,6 +723,7 @@ function getSize(size: number, defaultSize: number, rangeElement: GoogleAppsScri
 function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRenderOptions, renderedEquationB64: string }[]) {
   const mathjaxRenderer = Common.getRenderer(Common.rendererIds.MATHJAX);
   let c = 0;
+  let alreadyRenderedCount = 0;
   console.log("MathJax client render completion received equations:", equations.length);
   
   // Go backwards so that the named ranges for multiple equations in the same paragraph don't get removed
@@ -743,6 +744,15 @@ function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRender
         continue;
       }
 
+      // REASON: if the range element is no longer Text (most commonly it's already an
+      // INLINE_IMAGE from a double-click render or an overlapping batch), placeImage's
+      // asText() threw a locale-dependent cast error — thousands of ERROR lines/day for
+      // what is a benign "already done" state. Skip quietly instead.
+      if (rangeElements[0].getElement().getType() !== DocumentApp.ElementType.TEXT) {
+        alreadyRenderedCount++;
+        continue;
+      }
+
       const equationBlob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
       const result = placeImage(rangeElements[0], equationBlob, mathjaxRenderer, equation.options.equationLinkEncoded, equation.options.size, equation.options.delim);
 
@@ -756,6 +766,9 @@ function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRender
     }
   }
   
+  if (alreadyRenderedCount > 0) {
+    console.log("MathJax client render completion skipped already-rendered ranges:", alreadyRenderedCount);
+  }
   return {
     lastStatus: DocsEquationRenderStatus.Success,
     successCount: c
@@ -970,17 +983,51 @@ function findInsertableAncestor(element: GoogleAppsScript.Document.Element) {
   return null;
 }
 
+// REASON: a doc with several unplaceable equations logged the same failure for every
+// equation on every retry (observed: one stuck user emitted ~2300 ERROR lines/day).
+// Log each distinct container type once per execution; the thrown error still carries
+// the message for the per-equation failure details.
+const reportedPlaceImageFailureTypes = new Set<string>();
+
 function placeImage(startElement: GoogleAppsScript.Document.RangeElement, renderedEquation: GoogleAppsScript.Base.Blob, renderer: AutoLatexCommon.Renderer, equation: string, size: number, delim: AutoLatexCommon.Delimiter) {
   // GET VARIABLES
-  const textElement = startElement.getElement().asText();
-  const text = textElement.getText();
-  const ancestor = findInsertableAncestor(textElement);
+  let textElement = startElement.getElement().asText();
+  const startOffset = startElement.getStartOffset();
+  const endOffsetInclusive = startElement.getEndOffsetInclusive();
+  let ancestor = findInsertableAncestor(textElement);
+  if (!ancestor) {
+    // REASON: prod logs show Text elements living DIRECTLY under a section
+    // (directParentType=BODY_SECTION) — no Paragraph wrapper, so no ancestor exposes
+    // insertInlineImage and rendering hard-failed for those docs. Sections do expose
+    // insertParagraph, so wrap the text in a fresh Paragraph at the same position and
+    // continue normally. The equations themselves are valid; only the container is odd.
+    const directParent = textElement.getParent();
+    const sectionLike = directParent as unknown as {
+      insertParagraph?: (index: number, text: string) => GoogleAppsScript.Document.Paragraph;
+      getChildIndex?: (child: GoogleAppsScript.Document.Element) => number;
+      removeChild?: (child: GoogleAppsScript.Document.Element) => unknown;
+    };
+    if (directParent && typeof sectionLike.insertParagraph === "function" &&
+        typeof sectionLike.getChildIndex === "function" && typeof sectionLike.removeChild === "function") {
+      const idx = sectionLike.getChildIndex(textElement);
+      const wrapper = sectionLike.insertParagraph(idx, "");
+      const movedText = wrapper.appendText(textElement.getText());
+      sectionLike.removeChild(textElement);
+      textElement = movedText;
+      ancestor = { container: wrapper as unknown as GoogleAppsScript.Document.ContainerElement, directChild: movedText as unknown as GoogleAppsScript.Document.Element };
+      console.log("placeImage: wrapped section-level text in a paragraph to place the equation.");
+    }
+  }
   if (!ancestor) {
     const directParent = textElement.getParent();
     const parentType = directParent && typeof directParent.getType === "function" ? String(directParent.getType()) : "<unknown>";
-    console.error("placeImage: no ancestor within 6 levels supports insertInlineImage. directParentType=", parentType, " equation=", equation);
+    if (!reportedPlaceImageFailureTypes.has(parentType)) {
+      reportedPlaceImageFailureTypes.add(parentType);
+      console.error("placeImage: no ancestor within 6 levels supports insertInlineImage. directParentType=", parentType, " equation=", equation);
+    }
     throw new Error(`Cannot place image: equation is in an unsupported container (direct parent type ${parentType}). Inline images can't be inserted here.`);
   }
+  const text = textElement.getText();
   // REASON: TypeScript's union of insertable containers (Body, TableCell, FootnoteSection,
   // Paragraph, ListItem, ...) is wide; the methods we actually call (insertInlineImage,
   // insertText, getChild, getChildIndex) exist on all of them at runtime. Cast to the
@@ -989,11 +1036,11 @@ function placeImage(startElement: GoogleAppsScript.Document.RangeElement, render
   const paragraph = ancestor.container as unknown as GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph;
   const childIndex = paragraph.getChildIndex(ancestor.directChild as GoogleAppsScript.Document.Element); //gets index of found text (or its containing wrapper) in the insertable ancestor
   const textCopy = textElement.asText().copy();
-  let endLimit = startElement.getEndOffsetInclusive();
+  let endLimit = endOffsetInclusive;
   if (text.length - 1 < endLimit) endLimit = text.length - 1;
   textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
   Common.reportDeltaTime(522);
-  textElement.editAsText().deleteText(startElement.getStartOffset(), text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
+  textElement.editAsText().deleteText(startOffset, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
   Common.reportDeltaTime(526);
   
   // try inserting twice
@@ -1123,7 +1170,15 @@ function removeAll(defaultDelimRaw: string) {
       }
       // console.log("Current origURL " + origURL, origURL == "null", origURL === null, typeof origURL, Object.is(origURL, null), null instanceof Object, origURL instanceof Object, origURL instanceof String, !origURL)
       // console.log("Current origURL " + image.getLinkUrl(), image.getLinkUrl() === null, typeof image.getLinkUrl(), Object.is(image.getLinkUrl(), null), !image.getLinkUrl())
-      const result = Common.derenderEquation(origURL, getDocsApp());
+      // REASON: same escape()-era %uXXXX guard as derenderInlineImage — one ancient
+      // image must not crash De-render All for the whole document.
+      let result: ReturnType<typeof Common.derenderEquation>;
+      try {
+        result = Common.derenderEquation(origURL, getDocsApp());
+      } catch (err) {
+        console.error("removeAll: failed to decode equation URL; skipping image.", String(err), " url=", String(origURL).substring(0, 500));
+        continue;
+      }
       if (!result) continue;
       const { origEq, delim: newDelim } = result;
       const delim = newDelim || defaultDelim;
@@ -1160,7 +1215,17 @@ function derenderInlineImage(
   if (!origURL) {
     return Common.DerenderResult.NullUrl;
   }
-  const result = Common.derenderEquation(origURL, getDocsApp());
+  // REASON: images rendered in the escape()-encoding era carry %uXXXX sequences that
+  // decodeURIComponent rejects (URIError: URI malformed). Uncaught, one ancient image
+  // crashed the whole De-render run. Log WITH the URL so the offending encoding is
+  // visible, and skip just this image.
+  let result: ReturnType<typeof Common.derenderEquation>;
+  try {
+    result = Common.derenderEquation(origURL, getDocsApp());
+  } catch (err) {
+    console.error("derenderInlineImage: failed to decode equation URL; skipping image.", String(err), " url=", String(origURL).substring(0, 500));
+    return Common.DerenderResult.InvalidUrl;
+  }
   if (!result) return Common.DerenderResult.InvalidUrl;
   const { delim: newDelim, origEq } = result;
   const delim = newDelim || defaultDelim;

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -838,7 +838,16 @@ function buildClientRenderResponse(
   // silently merging align/matrix rows and degrading "\\\hline" -> "\\hline" ->
   // (after a derender round-trip) a bare "\hline", which MathJax rejects as
   // "Misplaced \hline".
-  const clientEquation = decodeURIComponent(equationOriginal.split("%5C%5C%5C%5C").join("%5C%5C"));
+  const clientEquation = decodeURIComponent(
+    equationOriginal
+      // REASON: restore the reEncode newline marker to a literal \r (what the doc
+      // actually contained) instead of pre-converting to "\\". The client decides
+      // per-position whether a newline is a row break or cosmetic paste formatting
+      // (inside environments), and derender round-trips stay byte-identical.
+      .split("%5C%5C%5C%5C%20").join("%0D")
+      // legacy doubled row breaks, same collapse as the Codecogs path
+      .split("%5C%5C%5C%5C").join("%5C%5C")
+  );
   const doc = DocumentApp.getActiveDocument();
   const range = doc.newRange()
     .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -795,11 +795,20 @@ function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.Range
   const colorHex = textElement.getForegroundColor(startElement.getStartOffset());
   // Docs can return null or malformed colors in some edge cases. Fall back to black.
   const [r, g, b] = getRgbFromHex(colorHex);
-  
+
+  // REASON: users build dark documents by highlighting text with a dark background
+  // color; the transparent equation PNG then shows the white page through the
+  // highlight band, making light-colored equations invisible. Sample the text's
+  // background color so the client bakes it into the image. No highlight (null)
+  // keeps the image transparent, exactly as before.
+  const bgHex = textElement.getBackgroundColor(startElement.getStartOffset());
+  const bgColor = bgHex ? getRgbFromHex(bgHex) : null;
+
   // add color info to render options
   const coloredRenderOptions = {
     ...renderOptions,
     r, g, b,
+    ...(bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}),
   };
   
   // REASON: Explicit MathJax and Automatic both render on the client first.
@@ -1126,9 +1135,81 @@ function removeAll(defaultDelimRaw: string) {
  * @public
  */
 
+// Derender one equation image in place: insert the recovered LaTeX text at the
+// image's position in its parent and remove the image.
+function derenderInlineImage(
+  image: GoogleAppsScript.Document.InlineImage,
+  defaultDelim: AutoLatexCommon.Delimiter
+) {
+  const origURL = image.getLinkUrl();
+  if (!origURL) {
+    return Common.DerenderResult.NullUrl;
+  }
+  const result = Common.derenderEquation(origURL, getDocsApp());
+  if (!result) return Common.DerenderResult.InvalidUrl;
+  const { delim: newDelim, origEq } = result;
+  const delim = newDelim || defaultDelim;
+  if (origEq.length <= 0) {
+    console.log("Empty equation derender.");
+    return Common.DerenderResult.EmptyEquation;
+  }
+  const parent = image.getParent() as GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph;
+  const imageIndex = parent.getChildIndex(image);
+  parent.insertText(imageIndex, delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
+  image.removeFromParent();
+  return Common.DerenderResult.Success;
+}
+
+// Collect equation-candidate inline images from the user's selection, in document
+// order. Handles both a directly selected image and selections that span
+// paragraphs/list items containing images.
+function collectSelectedInlineImages(selection: GoogleAppsScript.Document.Range) {
+  const images: GoogleAppsScript.Document.InlineImage[] = [];
+  for (const rangeElement of selection.getRangeElements()) {
+    const el = rangeElement.getElement();
+    const elType = el.getType();
+    if (elType === DocumentApp.ElementType.INLINE_IMAGE) {
+      images.push(el.asInlineImage());
+    } else if (elType === DocumentApp.ElementType.PARAGRAPH || elType === DocumentApp.ElementType.LIST_ITEM) {
+      const container = el as GoogleAppsScript.Document.Paragraph | GoogleAppsScript.Document.ListItem;
+      for (let i = 0; i < container.getNumChildren(); i++) {
+        const child = container.getChild(i);
+        if (child.getType() === DocumentApp.ElementType.INLINE_IMAGE) {
+          images.push(child.asInlineImage());
+        }
+      }
+    }
+  }
+  return images;
+}
+
 function editEquations(sizeRaw: string, delimiter: string, renderer: string = "auto") {
   const defaultDelim = Common.getDelimiters(delimiter);
   Common.savePrefs(sizeRaw, delimiter, renderer);
+
+  // REASON: users naturally click/select the equation image itself and hit
+  // De-render; the cursor-only flow returned CursorNotFound for that (a selection
+  // means there is no cursor). Derender every equation image in the selection —
+  // in reverse document order so earlier removals can't shift later indices.
+  const selection = DocumentApp.getActiveDocument().getSelection();
+  if (selection) {
+    const images = collectSelectedInlineImages(selection);
+    if (images.length === 0) {
+      return Common.DerenderResult.NonExistentElement;
+    }
+    let successCount = 0;
+    let lastFailureResult = Common.DerenderResult.InvalidUrl;
+    for (const image of images.reverse()) {
+      const result = derenderInlineImage(image, defaultDelim);
+      if (result === Common.DerenderResult.Success) {
+        successCount++;
+      } else {
+        lastFailureResult = result;
+      }
+    }
+    return successCount > 0 ? Common.DerenderResult.Success : lastFailureResult;
+  }
+
   const cursor = DocumentApp.getActiveDocument().getCursor();
   if (!cursor) {
     return Common.DerenderResult.CursorNotFound;
@@ -1169,20 +1250,5 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
 
   const image = childAtCursor.asInlineImage();
   Common.debugLog("Image height", image.getHeight());
-  const origURL = image.getLinkUrl();
-  if (!origURL) {
-    return Common.DerenderResult.NullUrl;
-  }
-  Common.debugLog("Original URL from image", origURL);
-  const result = Common.derenderEquation(origURL, getDocsApp());
-  if (!result) return Common.DerenderResult.InvalidUrl;
-  const { delim: newDelim, origEq } = result;
-  const delim = newDelim || defaultDelim;
-  if (origEq.length <= 0) {
-    console.log("Empty equation derender.");
-    return Common.DerenderResult.EmptyEquation;
-  }
-  cursor.insertText(delim[0] + origEq + delim[1]); //INSERTS DELIMITERS
-  element.getChild(position + 1).removeFromParent();
-  return Common.DerenderResult.Success;
+  return derenderInlineImage(image, defaultDelim);
 }

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -1210,7 +1210,7 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
   if (selection) {
     const images = collectSelectedInlineImages(selection);
     if (images.length === 0) {
-      return Common.DerenderResult.NonExistentElement;
+      return { result: Common.DerenderResult.NonExistentElement, successCount: 0 };
     }
     let successCount = 0;
     let lastFailureResult = Common.DerenderResult.InvalidUrl;
@@ -1222,17 +1222,19 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
         lastFailureResult = result;
       }
     }
-    return successCount > 0 ? Common.DerenderResult.Success : lastFailureResult;
+    return successCount > 0
+      ? { result: Common.DerenderResult.Success, successCount }
+      : { result: lastFailureResult, successCount: 0 };
   }
 
   const cursor = DocumentApp.getActiveDocument().getCursor();
   if (!cursor) {
-    return Common.DerenderResult.CursorNotFound;
+    return { result: Common.DerenderResult.CursorNotFound, successCount: 0 };
   }
 
   const elementRaw = cursor.getElement();
   if (!elementRaw) {
-    return Common.DerenderResult.NonExistentElement;
+    return { result: Common.DerenderResult.NonExistentElement, successCount: 0 };
   }
 
   // REASON: Cursor.getElement() can return any Element subtype (Table, TableOfContents,
@@ -1243,7 +1245,7 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
   const elementType = elementRaw.getType();
   if (elementType !== DocumentApp.ElementType.PARAGRAPH && elementType !== DocumentApp.ElementType.LIST_ITEM) {
     console.log("editEquations: cursor is in unsupported element type", elementType);
-    return Common.DerenderResult.NonExistentElement;
+    return { result: Common.DerenderResult.NonExistentElement, successCount: 0 };
   }
 
   const element = elementRaw as GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph;
@@ -1251,7 +1253,7 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
 
   const position = cursor.getOffset(); //offset
   if (position >= element.getNumChildren()) {
-    return Common.DerenderResult.CursorNotFound;
+    return { result: Common.DerenderResult.CursorNotFound, successCount: 0 };
   }
 
   // REASON: getChild(position).asInlineImage() throws "TEXT can't be cast to INLINE_IMAGE"
@@ -1260,10 +1262,14 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
   const childAtCursor = element.getChild(position);
   if (childAtCursor.getType() !== DocumentApp.ElementType.INLINE_IMAGE) {
     console.log("editEquations: child at cursor is not an inline image", childAtCursor.getType());
-    return Common.DerenderResult.NonExistentElement;
+    return { result: Common.DerenderResult.NonExistentElement, successCount: 0 };
   }
 
   const image = childAtCursor.asInlineImage();
   Common.debugLog("Image height", image.getHeight());
-  return derenderInlineImage(image, defaultDelim);
+  const cursorResult = derenderInlineImage(image, defaultDelim);
+  return {
+    result: cursorResult,
+    successCount: cursorResult === Common.DerenderResult.Success ? 1 : 0
+  };
 }

--- a/Docs/Sidebar.html
+++ b/Docs/Sidebar.html
@@ -104,7 +104,7 @@
           <label id="tips">
             <br />
             <b>Tips:</b> <br />
-            • Place your cursor right before the equation and click "De-render Equation" to convert back to code. <br />
+            • Click a rendered equation (or select several) and click "De-render Equation" to convert back to code. <br />
             • Use shift+enter instead of enter for newlines in multi-line equations. Shift+enter auto-converts to \\.
             <!-- <br> • Click the sidebar and press ctrl+q to derender all equations. (beta) -->
             <br />
@@ -124,7 +124,7 @@
               students.</b
             ><br />
             • Check out Auto-LaTeX in your Slides presentations!<br />
-            • Check out the latest <a href="https://sites.google.com/site/autolatexequations/" target="_blank">2022 Update Notes</a>. <br />
+            • Check out the latest <a href="https://sites.google.com/site/autolatexequations/" target="_blank">2026 Update Notes</a>. <br />
             • Find a full list of commands at <a href="http://www.codecogs.com/eqnedit.php" target="_blank">CodeCogs</a>. <br />
             • Problems? Check the <a href="https://www.autolatex.com/faq" target="_blank">FAQ</a>, email
             <a href="mailto:autolatex@gmail.com" target="_blank">autolatex@gmail.com</a>, or check updates on

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -16,6 +16,9 @@ interface Window {
 
 declare const MathJax: MathJaxApi;
 
+// implemented in ../SidebarMathJaxShared.ts, injected ahead of this file by BuildSidebarJS.js
+declare function prepareEquationForMathJax(equation: string): string;
+
 // animation timeout ID
 // REASON: setInterval return type conflicts between DOM lib (number) and Node @types
 // (Timeout) when both are in scope during Sidebar.ts compilation. The runtime contract is
@@ -252,73 +255,10 @@ async function blobToB64(blob: Blob) {
   return dataUrl.substring(dataUrl.indexOf(",") + 1); // strip dataurl header
 }
 
-function hasNonAsciiText(value: string) {
-  return value.split("").some(char => char.charCodeAt(0) > 0x7F);
-}
-
-// REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
-// LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
-// content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
-// puts environments on their own lines). Only the remaining depth-0 newlines mean
-// "new output line" — the sidebar's shift+enter contract. An explicit \\ followed
-// by a newline collapses to a single row break instead of adding an empty line.
-function replaceNewlinesDepthAware(equation: string) {
-  let depth = 0;
-  let result = "";
-  for (let i = 0; i < equation.length; i++) {
-    const ch = equation.charAt(i);
-    if (ch === "\\") {
-      if (equation.startsWith("\\begin", i)) {
-        depth++;
-      } else if (equation.startsWith("\\end", i)) {
-        depth = Math.max(0, depth - 1);
-      }
-      // copy escape pairs atomically so \\ never half-matches the checks above
-      result += ch;
-      if (i + 1 < equation.length) {
-        result += equation.charAt(i + 1);
-        i++;
-      }
-      continue;
-    }
-    if (ch === "\n" || ch === "\r" || ch === "\u000B") {
-      const upcoming = equation.slice(i + 1).replace(/^[\s\u000B]+/, "");
-      const cosmeticBoundary =
-        depth > 0 ||
-        upcoming.startsWith("\\begin") ||
-        /\\end\s*\{[^{}]*\}\s*$/.test(result);
-      if (cosmeticBoundary) {
-        result += " ";
-      } else if (/\\\\\s*$/.test(result)) {
-        result += " "; // already ends with an explicit row break; don't double it
-      } else {
-        result += "\\\\";
-      }
-      continue;
-    }
-    result += ch;
-  }
-  return result;
-}
-
 async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRenderOptions) {
-  const equationForMathJax = renderOptions.equation
-    .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    // REASON: renders/derenders performed while the pre-2026-07 backslash collapse
-    // was live permanently stripped one backslash from "\\\hline" in user docs,
-    // leaving the exact 2-backslash signature "\\hline" (row break + literal
-    // "hline" text). Repair it; a pristine 3-backslash run can't match this regex.
-    .replace(/(^|[^\\])\\\\hline/g, "$1\\\\ \\hline");
-  let equationBody = replaceNewlinesDepthAware(equationForMathJax);
-  // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
-  // equations (which the sidebar instructions promise, and which Codecogs honors)
-  // silently rendered on one line. Wrap top-level \\ in gathered to restore the
-  // promised line breaks. Equations that already use an environment (align, table,
-  // gathered, ...) are left alone — their \\ belongs to that environment.
-  if (/\\\\/.test(equationBody) && !/\\begin\s*\{/.test(equationBody)) {
-    equationBody = `\\begin{gathered}${equationBody}\\end{gathered}`;
-  }
+  // preprocessing (mbox/mathrm unicode, damaged-hline repair, depth-aware
+  // newlines, gathered wrap) lives in ../SidebarMathJaxShared.ts
+  const equationBody = prepareEquationForMathJax(renderOptions.equation);
   const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
   
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -16,8 +16,6 @@ interface Window {
 
 declare const MathJax: MathJaxApi;
 
-// implemented in ../SidebarMathJaxShared.ts, injected ahead of this file by BuildSidebarJS.js
-declare function prepareEquationForMathJax(equation: string): string;
 
 // animation timeout ID
 // REASON: setInterval return type conflicts between DOM lib (number) and Node @types
@@ -220,143 +218,19 @@ window.addEventListener("unhandledrejection", event => {
   reportMathJaxClientError("window.unhandledrejection", event.reason);
 });
 
-// REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in parallel
-// (e.g. 1000 equations) would freeze the browser. This limits concurrency to a safe number.
-const MATHJAX_CONCURRENCY_LIMIT = 4;
-
-async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < items.length) {
-      const index = nextIndex++;
-      results[index] = await fn(items[index]);
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
-  return results;
-}
-
-/**
-* Convert a Blob to a base64 string for transmission to the server
-*
-* @param blob the blob to convert
-* @returns
-*/
-async function blobToB64(blob: Blob) {
-  const dataUrl = await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result as string);
-    reader.onerror = err => reject(err);
-    reader.readAsDataURL(blob);
-  });
-  return dataUrl.substring(dataUrl.indexOf(",") + 1); // strip dataurl header
-}
+// Shared MathJax machinery (mapWithConcurrency, blobToB64, MATHJAX_CONCURRENCY_LIMIT,
+// renderEquationPngWithMathJax) is implemented in ../SidebarMathJaxShared.ts and
+// injected ahead of this file by BuildSidebarJS.js.
+declare const MATHJAX_CONCURRENCY_LIMIT: number;
+declare function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]>;
+declare function blobToB64(blob: Blob): Promise<string>;
+declare function renderEquationPngWithMathJax(
+  renderOptions: { equation: string; inline: boolean; size: number; r: number; g: number; b: number; bgR?: number; bgG?: number; bgB?: number },
+  reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
+): Promise<Blob>;
 
 async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRenderOptions) {
-  // preprocessing (mbox/mathrm unicode, damaged-hline repair, depth-aware
-  // newlines, gathered wrap) lives in ../SidebarMathJaxShared.ts
-  const equationBody = prepareEquationForMathJax(renderOptions.equation);
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
-  
-  if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
-    throw new Error("MathJax is still loading. Please try again in a moment.");
-  }
-
-  const result = await window.MathJax.tex2svgPromise(equation, {
-    display: !renderOptions.inline,
-    em: renderOptions.size
-  });
-  const svg: SVGSVGElement = result.querySelector("svg");
-  if (!svg) {
-    throw new Error("MathJax did not return an SVG element.");
-  }
-
-  // REASON: tex2svgPromise RESOLVES on TeX syntax errors, embedding the message as a
-  // red merror node — so bad equations were silently inserted as error images with no
-  // trace in Cloud Logging. Report them (with the equation) so they're debuggable;
-  // rendering still proceeds so one bad equation can't fail the whole batch.
-  const mjxErrorNode = svg.querySelector("[data-mjx-error]");
-  if (mjxErrorNode) {
-    reportMathJaxClientError("mathjax.merror", mjxErrorNode.getAttribute("data-mjx-error") || "unknown TeX error", {
-      equation: renderOptions.equation,
-    });
-  }
-  
-  // calculate width and height by rendering this svg with the specified font size
-  svg.classList.add("mathjax-equation-hidden-render");
-  svg.style.fontSize = `${renderOptions.size}px`;
-  document.body.appendChild(svg);
-  
-  // scale up by 5
-  const width = svg.clientWidth * 5;
-  const height = svg.clientHeight * 5;
-  
-  svg.remove();
-  
-  // set width/height explicitly on the svg
-  svg.setAttribute("width", `${width}px`);
-  svg.setAttribute("height", `${height}px`);
-  
-  const styles = MathJax.svgStylesheet().outerHTML;
-  
-  // create a URL for this svg
-  const svgString = new XMLSerializer().serializeToString(svg)
-    // inject css
-    .replace("</svg>", styles + "</svg>");
-  const svgBlob = new Blob([svgString], {
-    type: "image/svg+xml"
-  });
-  
-  const svgUrl = URL.createObjectURL(svgBlob);
-  
-  const canvas = typeof OffscreenCanvas !== "undefined"
-    ? new OffscreenCanvas(width, height)
-    : Object.assign(document.createElement("canvas"), { width, height });
-  const ctx = canvas.getContext("2d");
-  if (!ctx) {
-    throw new Error("Could not initialize a 2D canvas for MathJax rendering.");
-  }
-
-  // REASON: when the equation text carries a highlight (background color), the
-  // server samples it into bgR/bgG/bgB; bake it into the PNG so the image matches
-  // the highlight band instead of showing the white page through a transparent
-  // background. Absent -> transparent, exactly the previous behavior.
-  if (typeof renderOptions.bgR === "number") {
-    ctx.fillStyle = `rgb(${renderOptions.bgR},${renderOptions.bgG},${renderOptions.bgB})`;
-    ctx.fillRect(0, 0, width, height);
-  }
-
-  try {
-    // load this svg on an image
-    const svgImage = new Image(width, height);
-    svgImage.src = svgUrl;
-    // wait for load
-    await new Promise<void>((resolve, reject) => {
-      svgImage.onload = () => resolve();
-      svgImage.onerror = err => reject(err);
-    });
-    
-    // draw onto canvas
-    ctx.drawImage(svgImage, 0, 0);
-    
-    const pngBlob = "convertToBlob" in canvas
-      ? await canvas.convertToBlob({ type: "image/png" })
-      : await new Promise<Blob>((resolve, reject) => {
-          (canvas as HTMLCanvasElement).toBlob(blob => {
-            if (blob) {
-              resolve(blob);
-            } else {
-              reject(new Error("Could not convert MathJax canvas to a PNG blob."));
-            }
-          }, "image/png");
-        });
-    return pngBlob;
-  } finally {
-    URL.revokeObjectURL(svgUrl);
-  }
+  return renderEquationPngWithMathJax(renderOptions, reportMathJaxClientError);
 }
 
 /**

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -261,7 +261,16 @@ async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRender
     .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
     .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
   // apply RGB coloring + newline becomes \\
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+  let equationBody = equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+  // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
+  // equations (which the sidebar instructions promise, and which Codecogs honors)
+  // silently rendered on one line. Wrap top-level \\ in gathered to restore the
+  // promised line breaks. Equations that already use an environment (align, table,
+  // gathered, ...) are left alone — their \\ belongs to that environment.
+  if (/\\\\/.test(equationBody) && !/\\begin\s*\{/.test(equationBody)) {
+    equationBody = `\\begin{gathered}${equationBody}\\end{gathered}`;
+  }
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
   
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
     throw new Error("MathJax is still loading. Please try again in a moment.");

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -256,12 +256,61 @@ function hasNonAsciiText(value: string) {
   return value.split("").some(char => char.charCodeAt(0) > 0x7F);
 }
 
+// REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
+// LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
+// content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
+// puts environments on their own lines). Only the remaining depth-0 newlines mean
+// "new output line" — the sidebar's shift+enter contract. An explicit \\ followed
+// by a newline collapses to a single row break instead of adding an empty line.
+function replaceNewlinesDepthAware(equation: string) {
+  let depth = 0;
+  let result = "";
+  for (let i = 0; i < equation.length; i++) {
+    const ch = equation.charAt(i);
+    if (ch === "\\") {
+      if (equation.startsWith("\\begin", i)) {
+        depth++;
+      } else if (equation.startsWith("\\end", i)) {
+        depth = Math.max(0, depth - 1);
+      }
+      // copy escape pairs atomically so \\ never half-matches the checks above
+      result += ch;
+      if (i + 1 < equation.length) {
+        result += equation.charAt(i + 1);
+        i++;
+      }
+      continue;
+    }
+    if (ch === "\n" || ch === "\r" || ch === "\u000B") {
+      const upcoming = equation.slice(i + 1).replace(/^[\s\u000B]+/, "");
+      const cosmeticBoundary =
+        depth > 0 ||
+        upcoming.startsWith("\\begin") ||
+        /\\end\s*\{[^{}]*\}\s*$/.test(result);
+      if (cosmeticBoundary) {
+        result += " ";
+      } else if (/\\\\\s*$/.test(result)) {
+        result += " "; // already ends with an explicit row break; don't double it
+      } else {
+        result += "\\\\";
+      }
+      continue;
+    }
+    result += ch;
+  }
+  return result;
+}
+
 async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRenderOptions) {
   const equationForMathJax = renderOptions.equation
     .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
-  // apply RGB coloring + newline becomes \\
-  let equationBody = equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    // REASON: renders/derenders performed while the pre-2026-07 backslash collapse
+    // was live permanently stripped one backslash from "\\\hline" in user docs,
+    // leaving the exact 2-backslash signature "\\hline" (row break + literal
+    // "hline" text). Repair it; a pristine 3-backslash run can't match this regex.
+    .replace(/(^|[^\\])\\\\hline/g, "$1\\\\ \\hline");
+  let equationBody = replaceNewlinesDepthAware(equationForMathJax);
   // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
   // equations (which the sidebar instructions promise, and which Codecogs honors)
   // silently rendered on one line. Wrap top-level \\ in gathered to restore the

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -319,7 +319,16 @@ async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRender
   if (!ctx) {
     throw new Error("Could not initialize a 2D canvas for MathJax rendering.");
   }
-  
+
+  // REASON: when the equation text carries a highlight (background color), the
+  // server samples it into bgR/bgG/bgB; bake it into the PNG so the image matches
+  // the highlight band instead of showing the white page through a transparent
+  // background. Absent -> transparent, exactly the previous behavior.
+  if (typeof renderOptions.bgR === "number") {
+    ctx.fillStyle = `rgb(${renderOptions.bgR},${renderOptions.bgG},${renderOptions.bgB})`;
+    ctx.fillRect(0, 0, width, height);
+  }
+
   try {
     // load this svg on an image
     const svgImage = new Image(width, height);

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -650,17 +650,14 @@ function editText(){
   const {sizeRaw, delimiter, renderer} = getCurrentSettings();
   google.script.run
     .withSuccessHandler(
-      function(returnSuccess: AutoLatexCommon.DerenderResult, element) {
+      function(returnSuccess: { result: AutoLatexCommon.DerenderResult, successCount: number }, element) {
         if (isStaleSidebarAction(actionId)) {
           return;
         }
         $("#loading").html('');
         restoreIdleSidebarControls();
-        $("#loading").html("Status: " + "1"             + " equation replaced.");
-        if(returnSuccess < 0)
-          $("#loading").html("Status: " + "No"          + " equations replaced.");
 
-        switch (returnSuccess) {
+        switch (returnSuccess.result) {
           case AutoLatexCommon.DerenderResult.InvalidUrl:
             showError("Cannot retrieve equation. The equation may not have been rendered by Auto-LaTeX.", "Status: Error, please ensure link is still on equation.");
             break;
@@ -676,15 +673,17 @@ function editText(){
             // (b) the cursor is inside an unsupported element type (table cell, footnote,
             // table of contents). Both used to crash with a TypeError. The combined hint
             // covers both without forcing a new enum value.
-            showError("Place your cursor immediately before the rendered equation image and try again. De-render only works on equations rendered by Auto-LaTeX inside a normal paragraph - it doesn't work inside tables, footnotes, or on plain text.", "Status: Error, please move cursor before the equation image.");
+            showError("Click (or select) the rendered equation image and try again \u2014 selection-based de-render works anywhere, including headers and footers. The cursor-before-the-image flow only works in normal paragraphs.", "Status: Error, please select the equation image.");
             break;
           case AutoLatexCommon.DerenderResult.CursorNotFound:
             showError("Cannot find a cursor/equation. Please click before an equation.", "Status: Error, please move cursor before equation.");
             break;
           case AutoLatexCommon.DerenderResult.Success:
-          default:
-            $("#loading").html("Status: 1 equation de-rendered.");
+          default: {
+            const n = returnSuccess.successCount || 1;
+            $("#loading").html(`Status: ${n} equation${n === 1 ? "" : "s"} de-rendered.`);
             break;
+          }
         }
       })
     .withFailureHandler(

--- a/Sheets/Code.ts
+++ b/Sheets/Code.ts
@@ -39,6 +39,26 @@ interface SheetsRenderResult {
   authorizationError: boolean;
   noSpreadsheet: boolean;
   failureDetails?: SheetsFailureDetail[];
+  // present when the sidebar should render these client-side via MathJax and
+  // call clientRenderComplete / clientRenderFailed with the results
+  clientEquations?: SheetsClientRenderOptions[];
+}
+
+// One cell's equation handed to the sidebar for client-side MathJax rendering.
+// Cells are addressed by sheetId + row/col (Sheets needs no named-range machinery:
+// the anchor cell is the identity), and the original cell value rides along so the
+// completion path can build the round-trip alt text and detect stale cells.
+interface SheetsClientRenderOptions {
+  sheetId: number;
+  row: number;
+  col: number;
+  equation: string;
+  originalCellValue: string;
+  size: number;
+  inline: boolean;
+  r: number;
+  g: number;
+  b: number;
 }
 
 interface SheetsFailureDetail {
@@ -189,9 +209,24 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     return { successCount: 0, failureCount: 0, authorizationError: false, noSpreadsheet: true };
   }
 
-  // REASON: The renderer param mirrors Docs's; in Sheets we only run the server
-  // renderers today (no MathJax client fallback), so clientRender is always false. The
-  // user's chosen renderer narrows which server families Common tries.
+  // REASON: MathJax (best) and Automatic render on the client like Docs/Slides —
+  // that's the only path that supports tables, long equations, and the rest of the
+  // MathJax feature set. Scan the sheet, hand the equations to the sidebar, and let
+  // clientRenderComplete place the PNGs. Explicit server-renderer choices keep the
+  // in-process loop below.
+  if (renderer === "mathjax" || renderer === "auto") {
+    const clientEquations = collectClientEquations(spreadsheet, delimiterSet, size, isInline);
+    return {
+      successCount: 0,
+      failureCount: 0,
+      authorizationError: false,
+      noSpreadsheet: false,
+      clientEquations,
+    };
+  }
+
+  // REASON: The renderer param mirrors Docs's; the user chose an explicit server
+  // renderer, which narrows which families Common tries.
   const renderOptions: AutoLatexCommon.RenderOptions = {
     r: 0, g: 0, b: 0,
     delim: delimiterSet[0],
@@ -275,7 +310,7 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
         }
 
         try {
-          insertRenderedImage(sheet, r + 1, c + 1, cellRaw, result, size);
+          insertRenderedImage(sheet, r + 1, c + 1, cellRaw, result.resp!.getBlob(), size);
           successCount++;
         } catch (err) {
           console.error("insertRenderedImage failed:", err);
@@ -309,15 +344,161 @@ function mapRendererToServerFamilies(renderer: string): string[] | undefined {
   }
 }
 
+/**
+ * Scan every sheet for whole-cell equations and package them for client-side
+ * MathJax rendering. Fast (bulk reads only, no fetches), so no time budget needed.
+ */
+function collectClientEquations(
+  spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet,
+  delimiterSet: AutoLatexCommon.Delimiter[],
+  size: number,
+  isInline: boolean
+): SheetsClientRenderOptions[] {
+  const clientEquations: SheetsClientRenderOptions[] = [];
+  for (const sheet of spreadsheet.getSheets()) {
+    const lastRow = sheet.getLastRow();
+    const lastColumn = sheet.getLastColumn();
+    if (lastRow === 0 || lastColumn === 0) continue;
+    const dataRange = sheet.getRange(1, 1, lastRow, lastColumn);
+    const values = dataRange.getValues();
+    const fontColors = dataRange.getFontColors();
+    for (let r = 0; r < values.length; r++) {
+      for (let c = 0; c < values[r].length; c++) {
+        const cellRaw = values[r][c];
+        if (typeof cellRaw !== "string") continue;
+        let latex: string | null = null;
+        for (const candidateDelim of delimiterSet) {
+          latex = parseEquationCell(cellRaw, candidateDelim);
+          if (latex) break;
+        }
+        if (!latex) continue;
+        const [fontR, fontG, fontB] = getRgbFromHex(fontColors[r][c]);
+        // REASON: round-trip through reEncode + getClientEquation like Docs so cell
+        // newlines (\n) survive as literal newlines for the depth-aware client
+        // transform, and unicode gets the same normalization as every other surface.
+        const clientEquation = Common.getClientEquation(Common.reEncode(latex, SheetsApp), SheetsApp);
+        clientEquations.push({
+          sheetId: sheet.getSheetId(),
+          row: r + 1,
+          col: c + 1,
+          equation: clientEquation,
+          originalCellValue: cellRaw,
+          size,
+          inline: isInline,
+          r: fontR, g: fontG, b: fontB,
+        });
+      }
+    }
+  }
+  return clientEquations;
+}
+
+function findSheetById(spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet, sheetId: number) {
+  for (const sheet of spreadsheet.getSheets()) {
+    if (sheet.getSheetId() === sheetId) return sheet;
+  }
+  return null;
+}
+
+// Place one client- or server-rendered equation image, verifying the cell hasn't
+// changed since the scan (rendering happens asynchronously in the sidebar).
+function placeEquationImageAtCell(
+  options: SheetsClientRenderOptions,
+  blob: GoogleAppsScript.Base.Blob,
+  failureDetails: SheetsFailureDetail[]
+): boolean {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = spreadsheet ? findSheetById(spreadsheet, options.sheetId) : null;
+  if (!sheet) return false;
+  const cell = sheet.getRange(options.row, options.col);
+  // REASON: the user may have edited the cell while the client was rendering; only
+  // replace it if it still holds the exact equation we scanned.
+  if (cell.getValue() !== options.originalCellValue) {
+    failureDetails.push(buildFailureDetail(sheet, options.row, options.col, String(cell.getValue() || ""),
+      "Cell changed while rendering — run Render again"));
+    return false;
+  }
+  insertRenderedImage(sheet, options.row, options.col, options.originalCellValue, blob, options.size);
+  return true;
+}
+
+/**
+ * Called by the sidebar with client-rendered PNGs. Inserts each image at its cell.
+ * @public
+ */
+function clientRenderComplete(rendered: { options: SheetsClientRenderOptions, renderedEquationB64: string }[]): SheetsRenderResult {
+  let successCount = 0;
+  let failureCount = 0;
+  const failureDetails: SheetsFailureDetail[] = [];
+  for (const item of rendered) {
+    try {
+      const blob = Utilities.newBlob(Utilities.base64Decode(item.renderedEquationB64), "image/png", "equation.png");
+      if (placeEquationImageAtCell(item.options, blob, failureDetails)) {
+        successCount++;
+      } else {
+        failureCount++;
+      }
+    } catch (err) {
+      console.error("clientRenderComplete insertion failed:", err);
+      failureCount++;
+    }
+  }
+  return { successCount, failureCount, authorizationError: false, noSpreadsheet: false,
+    failureDetails: failureDetails.length ? failureDetails : undefined };
+}
+
+/**
+ * Called by the sidebar when MathJax couldn't render some equations (auto mode).
+ * Tries the non-Codecogs server renderers for just those cells, mirroring Docs.
+ * @public
+ */
+function clientRenderFailed(equations: { options: SheetsClientRenderOptions }[]): SheetsRenderResult {
+  let successCount = 0;
+  let failureCount = 0;
+  let authorizationError = false;
+  const failureDetails: SheetsFailureDetail[] = [];
+  console.log("MathJax client render failed, trying server fallback for", equations.length, "equations");
+  for (const { options } of equations) {
+    try {
+      // options.equation is the decoded client equation (delimiters already stripped
+      // at scan time); re-encode it for the server renderers.
+      const equationEncoded = Common.reEncode(options.equation, SheetsApp);
+      const result = Common.renderEquation(equationEncoded, {
+        r: options.r, g: options.g, b: options.b,
+        delim: Common.getDelimiters("$$"),
+        defaultSize: 11,
+        size: options.size,
+        inline: options.inline,
+        clientRender: false,
+        allowedServerFamilies: ["Texrendr", "Sciweavers", "Sciweavers_old", "Roger's renderer", "Number empire"],
+      });
+      if (result.worked > Common.capableRenderers || !result.resp || !result.renderer) {
+        if (result.authorizationError) authorizationError = true;
+        failureCount++;
+        continue;
+      }
+      if (placeEquationImageAtCell(options, result.resp.getBlob(), failureDetails)) {
+        successCount++;
+      } else {
+        failureCount++;
+      }
+    } catch (err) {
+      console.error("Server fallback render failed:", err);
+      failureCount++;
+    }
+  }
+  return { successCount, failureCount, authorizationError, noSpreadsheet: false,
+    failureDetails: failureDetails.length ? failureDetails : undefined };
+}
+
 function insertRenderedImage(
   sheet: GoogleAppsScript.Spreadsheet.Sheet,
   row: number,
   col: number,
   originalCellValue: string,
-  result: AutoLatexCommon.RenderEquationResult,
+  blob: GoogleAppsScript.Base.Blob,
   preferredSize: number
 ) {
-  const blob = result.resp!.getBlob();
   const image = sheet.insertImage(blob, col, row);
   // REASON: Anchor exactly to the cell so reflows/inserts that shift the cell carry the
   // image with them. Without setAnchorCell, OverGridImage uses absolute pixel coords.

--- a/Sheets/Code.ts
+++ b/Sheets/Code.ts
@@ -139,7 +139,23 @@ function parseEquationCell(rawText: string, delim: AutoLatexCommon.Delimiter): s
   if (!trimmed.startsWith(startToken) || !trimmed.endsWith(endToken)) return null;
   const inner = trimmed.substring(startToken.length, trimmed.length - endToken.length);
   if (!inner) return null;
+  // REASON: with the single-$ delimiter, a cell holding "$$x$$" would otherwise parse
+  // as the equation "$x$" (dollars included). The "all" set tries $$ before $, but a
+  // user who explicitly selected "$ ... $" still needs this guard.
+  if (delim[4] === 1 && startToken === "$" && (inner.startsWith("$") || inner.endsWith("$"))) return null;
   return inner;
+}
+
+// Parse a "#rrggbb" hex color into [r, g, b]; anything malformed falls back to black.
+function getRgbFromHex(colorHex: string | null): [number, number, number] {
+  if (!colorHex || !/^#[0-9a-fA-F]{6}$/.test(colorHex)) {
+    return [0, 0, 0];
+  }
+  const channels = [1, 3, 5].map(index => parseInt(colorHex.slice(index, index + 2), 16));
+  if (channels.some(channel => isNaN(channel))) {
+    return [0, 0, 0];
+  }
+  return channels as [number, number, number];
 }
 
 /**
@@ -193,7 +209,17 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
   let authorizationError = false;
   const failureDetails: SheetsFailureDetail[] = [];
 
+  // REASON: Apps Script kills executions at 6 minutes. A sheet full of equations
+  // rendered sequentially through server fetches can exceed that; stop cleanly with
+  // budget to spare so completed work is kept, and tell the user to run again —
+  // already-rendered cells no longer parse as equations, so the next run resumes
+  // where this one stopped.
+  const RENDER_TIME_BUDGET_MS = 270000;
+  const renderStartTime = Date.now();
+  let timeBudgetExceeded = false;
+
   for (const sheet of spreadsheet.getSheets()) {
+    if (timeBudgetExceeded) break;
     const lastRow = sheet.getLastRow();
     const lastColumn = sheet.getLastColumn();
     if (lastRow === 0 || lastColumn === 0) continue;
@@ -203,7 +229,10 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
     // per cell.
     const dataRange = sheet.getRange(1, 1, lastRow, lastColumn);
     const values = dataRange.getValues();
-    for (let r = 0; r < values.length; r++) {
+    // REASON: one bulk read per sheet; equations render in the cell's font color so
+    // colored/dark-themed sheets keep their equations visible (parity with Docs).
+    const fontColors = dataRange.getFontColors();
+    for (let r = 0; r < values.length && !timeBudgetExceeded; r++) {
       for (let c = 0; c < values[r].length; c++) {
         const cellRaw = values[r][c];
         if (typeof cellRaw !== "string") continue;
@@ -218,13 +247,24 @@ function replaceEquations(sizeRaw: string, delimiter: string, renderer: string =
         }
         if (!latex) continue;
 
+        if (Date.now() - renderStartTime > RENDER_TIME_BUDGET_MS) {
+          timeBudgetExceeded = true;
+          failureCount++;
+          failureDetails.push(buildFailureDetail(sheet, r + 1, c + 1, cellRaw,
+            "Stopped before the execution time limit — click Render Equations again to continue from here"));
+          break;
+        }
+
+        const [fontR, fontG, fontB] = getRgbFromHex(fontColors[r][c]);
+
         // REASON: Pre-encode the equation here the same way Docs does so that Common's
         // renderEquation receives a URL-safe payload with the correct newline glyph for
         // this surface (Sheets's \n → %0A vs Docs's paragraph-break → %0D).
         const equationEncoded = Common.reEncode(latex, SheetsApp);
         const result = Common.renderEquation(equationEncoded, {
           ...renderOptions,
-          delim
+          delim,
+          r: fontR, g: fontG, b: fontB
         });
 
         if (result.worked > Common.capableRenderers || !result.resp || !result.renderer) {
@@ -289,10 +329,16 @@ function insertRenderedImage(
   image.setAltTextTitle("Auto-LaTeX equation");
 
   // REASON: If the user requested an explicit pixel size via the sidebar's "Custom"
-  // option, apply it here. Default behavior leaves the image at its renderer-returned
-  // dimensions so the user can resize manually if needed.
+  // option, apply it here. Scale the width by the same factor — setHeight alone
+  // stretches the image because OverGridImage does not preserve aspect ratio.
   if (preferredSize > 0) {
-    image.setHeight(preferredSize * 4);
+    const currentHeight = image.getHeight();
+    const currentWidth = image.getWidth();
+    const targetHeight = preferredSize * 4;
+    image.setHeight(targetHeight);
+    if (currentHeight > 0 && currentWidth > 0) {
+      image.setWidth(Math.max(1, Math.round(currentWidth * targetHeight / currentHeight)));
+    }
   }
 
   // REASON: Clear the cell value AFTER inserting the image. If we cleared first and
@@ -391,6 +437,14 @@ function restoreEquationFromImage(image: GoogleAppsScript.Spreadsheet.OverGridIm
     return false;
   }
   const anchor = image.getAnchorCell();
+  // REASON: if the user typed a new value into the cell after rendering, restoring
+  // the LaTeX would silently destroy their data. Leave both the cell and the image
+  // alone; they can clear the cell and derender again if the restore is wanted.
+  const existingValue = anchor.getValue();
+  if (existingValue !== "" && existingValue !== null && existingValue !== undefined) {
+    console.warn("Skipping derender into non-empty cell " + anchor.getA1Notation());
+    return false;
+  }
   anchor.setValue(originalCellValue);
   image.remove();
   return true;

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -60,8 +60,9 @@
           </select>
           <br />
           <label id="select_size">Preferred Renderer:<br /></label>
-          <select id="renderer" name="renderer">
+          <select id="renderer" name="renderer" data-mathjax-enabled="true">
             <option value="auto" selected>Automatic</option>
+            <option value="mathjax">MathJax (best)</option>
             <option value="codecogs">Codecogs</option>
             <option value="texrendr">Texrendr</option>
             <option value="sciweavers">Sciweavers</option>

--- a/Sheets/Sidebar.html
+++ b/Sheets/Sidebar.html
@@ -118,7 +118,6 @@
         <img src="https://i.ibb.co/d2pJpb3/Donate-Button.png" width="100" height="34" alt="Donate" />
       </a>
     </div>
-    <script type="text/javascript" src="/nhpup_1.1.js"></script>
     <?!= HtmlService.createHtmlOutputFromFile('SidebarJS').getContent(); ?>
   </body>
 </html>

--- a/Sheets/Sidebar.ts
+++ b/Sheets/Sidebar.ts
@@ -25,6 +25,53 @@ interface SheetsRenderResult {
   authorizationError: boolean;
   noSpreadsheet: boolean;
   failureDetails?: SheetsFailureDetail[];
+  clientEquations?: SheetsClientRenderOptions[];
+}
+
+interface SheetsClientRenderOptions {
+  sheetId: number;
+  row: number;
+  col: number;
+  equation: string;
+  originalCellValue: string;
+  size: number;
+  inline: boolean;
+  r: number;
+  g: number;
+  b: number;
+}
+
+// Shared MathJax machinery from ../SidebarMathJaxShared.ts, injected ahead of this
+// file by BuildSidebarJS.js.
+declare const MATHJAX_CONCURRENCY_LIMIT: number;
+declare function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]>;
+declare function blobToB64(blob: Blob): Promise<string>;
+declare function renderEquationPngWithMathJax(
+  renderOptions: { equation: string; inline: boolean; size: number; r: number; g: number; b: number },
+  reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
+): Promise<Blob>;
+
+// REASON: mirrors the Docs/Slides client-error reporting so MathJax failures in
+// Sheets reach Cloud Logging with the offending equation. Deduped per session.
+const reportedMathJaxErrors = new Set<string>();
+function reportMathJaxClientError(context: string, error: unknown, extra: Record<string, unknown> = {}) {
+  const message = error instanceof Error ? error.message : String(error);
+  const dedupeKey = `${context}:${message}`;
+  if (reportedMathJaxErrors.has(dedupeKey)) {
+    return;
+  }
+  reportedMathJaxErrors.add(dedupeKey);
+  const payload = {
+    context,
+    error: { message, stack: error instanceof Error ? error.stack || "" : "" },
+    extra,
+    href: window.location.href,
+    userAgent: navigator.userAgent,
+    timestamp: new Date().toISOString(),
+  };
+  (google.script.run as any)
+    .withFailureHandler((logError: unknown) => console.error("Failed to report client error.", logError))
+    .logMathJaxClientError(JSON.stringify(payload));
 }
 
 interface SheetsDerenderResult {
@@ -100,7 +147,7 @@ function loadPreferences(choicePrefs: { size: string; delim: string; renderer: s
   // REASON: Older users may have Codecogs saved from when it was the practical default.
   // Open the sidebar on Automatic so Codecogs outages don't keep affecting them.
   const rendererPreference = choicePrefs.renderer === "codecogs" ? "auto" : choicePrefs.renderer;
-  const savedRenderer = ["auto", "texrendr", "sciweavers"].includes(rendererPreference) ? rendererPreference : "auto";
+  const savedRenderer = ["auto", "mathjax", "texrendr", "sciweavers"].includes(rendererPreference) ? rendererPreference : "auto";
   $('#renderer').val(savedRenderer);
   $('#insert-text').prop("disabled", false);
   $('#edit-text').prop("disabled", false);
@@ -155,6 +202,30 @@ function buildFailureDetailsHtml(failures: SheetsFailureDetail[] | undefined): s
   return html;
 }
 
+function showRenderResult(result: SheetsRenderResult) {
+  if (result.noSpreadsheet) {
+    showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", "Status: No spreadsheet.");
+    return;
+  }
+  if (result.authorizationError && result.successCount === 0) {
+    showError(
+      "<strong>Auto-LaTeX is missing permission to call external renderers.</strong> Try uninstalling and reinstalling the add-on, then click 'Select all' on the permissions screen.",
+      "Status: Authorization required"
+    );
+    return;
+  }
+  const failureHtml = buildFailureDetailsHtml(result.failureDetails);
+  if (result.successCount === 0 && result.failureCount === 0) {
+    $("#loading").html("Status: No equations found. Each equation must be the only content of its cell.");
+  } else if (result.successCount > 0 && result.failureCount === 0) {
+    $("#loading").html(`Status: ${result.successCount} equation${result.successCount === 1 ? "" : "s"} rendered.`);
+  } else if (result.successCount > 0 && result.failureCount > 0) {
+    showError(`Rendered ${result.successCount}, but ${result.failureCount} failed.${failureHtml}`, `Status: ${result.successCount} rendered, ${result.failureCount} failed.`);
+  } else {
+    showError(`All ${result.failureCount} equations failed.${failureHtml}`, "Status: All renderers failed.");
+  }
+}
+
 function insertText(this: HTMLButtonElement) {
   this.disabled = true;
   $('#error').remove();
@@ -165,29 +236,80 @@ function insertText(this: HTMLButtonElement) {
 
   google.script.run
     .withSuccessHandler(function (result: SheetsRenderResult) {
+      // REASON: MathJax (best) / Automatic return the scanned equations for
+      // client-side rendering: render them here (bounded concurrency, per-equation
+      // failure isolation), upload successes via clientRenderComplete, and in auto
+      // mode send only the failed subset to the server fallback.
+      if (result.clientEquations && result.clientEquations.length > 0) {
+        const equationsToRender = result.clientEquations;
+        $("#loading").html(`Status: Rendering ${equationsToRender.length} equation${equationsToRender.length === 1 ? "" : "s"}...`);
+        mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async eq => {
+          try {
+            return {
+              ok: true as const,
+              rendered: { options: eq, renderedEquationB64: await renderEquationPngWithMathJax(eq, reportMathJaxClientError).then(b => blobToB64(b)) }
+            };
+          } catch (err) {
+            reportMathJaxClientError("clientRenderEquation", err, { equation: eq.equation, equationLength: eq.equation.length });
+            return { ok: false as const, options: eq };
+          }
+        }).then(results => {
+          const rendered = results.filter(x => x.ok).map(x => (x as { ok: true, rendered: object }).rendered);
+          const failed = results.filter(x => !x.ok).map(x => ({ options: (x as { ok: false, options: SheetsClientRenderOptions }).options }));
+
+          const finish = (finalResult: SheetsRenderResult, extraFailures: number) => {
+            clearInterval(runDots);
+            element.disabled = false;
+            finalResult.failureCount += extraFailures;
+            showRenderResult(finalResult);
+          };
+
+          const handleFailedSet = (baseResult: SheetsRenderResult) => {
+            if (failed.length === 0) {
+              finish(baseResult, 0);
+              return;
+            }
+            if (renderer === "auto") {
+              (google.script.run as any)
+                .withSuccessHandler((fallbackResult: SheetsRenderResult) => {
+                  fallbackResult.successCount += baseResult.successCount;
+                  fallbackResult.failureCount += baseResult.failureCount;
+                  if (baseResult.failureDetails) {
+                    fallbackResult.failureDetails = (fallbackResult.failureDetails || []).concat(baseResult.failureDetails);
+                  }
+                  finish(fallbackResult, 0);
+                })
+                .withFailureHandler(() => finish(baseResult, failed.length))
+                .clientRenderFailed(failed);
+            } else {
+              finish(baseResult, failed.length);
+            }
+          };
+
+          if (rendered.length > 0) {
+            (google.script.run as any)
+              .withSuccessHandler((completeResult: SheetsRenderResult) => handleFailedSet(completeResult))
+              .withFailureHandler(function (msg: unknown) {
+                clearInterval(runDots);
+                element.disabled = false;
+                showError("Sorry, inserting rendered equations failed. " + ((msg as { message?: string })?.message ?? ""), "Status: Error.");
+              })
+              .clientRenderComplete(rendered);
+          } else {
+            handleFailedSet({ successCount: 0, failureCount: 0, authorizationError: false, noSpreadsheet: false });
+          }
+        }).catch(err => {
+          clearInterval(runDots);
+          element.disabled = false;
+          reportMathJaxClientError("clientRenderBatch", err, { equationCount: equationsToRender.length });
+          showError("Sorry, MathJax rendering failed. " + String((err as Error)?.message ?? err), "Status: Error.");
+        });
+        return;
+      }
+
       clearInterval(runDots);
       element.disabled = false;
-      if (result.noSpreadsheet) {
-        showError("Sorry, the script has conflicting authorizations. Try signing out of other active Gsuite accounts.", "Status: No spreadsheet.");
-        return;
-      }
-      if (result.authorizationError && result.successCount === 0) {
-        showError(
-          "<strong>Auto-LaTeX is missing permission to call external renderers.</strong> Try uninstalling and reinstalling the add-on, then click 'Select all' on the permissions screen.",
-          "Status: Authorization required"
-        );
-        return;
-      }
-      const failureHtml = buildFailureDetailsHtml(result.failureDetails);
-      if (result.successCount === 0 && result.failureCount === 0) {
-        $("#loading").html("Status: No equations found. Each equation must be the only content of its cell.");
-      } else if (result.successCount > 0 && result.failureCount === 0) {
-        $("#loading").html(`Status: ${result.successCount} equation${result.successCount === 1 ? "" : "s"} rendered.`);
-      } else if (result.successCount > 0 && result.failureCount > 0) {
-        showError(`Rendered ${result.successCount}, but ${result.failureCount} failed.${failureHtml}`, `Status: ${result.successCount} rendered, ${result.failureCount} failed.`);
-      } else {
-        showError(`All ${result.failureCount} equations failed.${failureHtml}`, "Status: All renderers failed.");
-      }
+      showRenderResult(result);
     })
     .withFailureHandler(function (msg) {
       clearInterval(runDots);

--- a/SidebarMathJaxShared.ts
+++ b/SidebarMathJaxShared.ts
@@ -1,9 +1,151 @@
 /// <reference lib="dom" />
 
-// Shared client-side MathJax equation preprocessing, injected into the Docs and
-// Slides SidebarJS.html by BuildSidebarJS.js (compiled to SidebarMathJaxShared.js).
-// Keep this file free of project-specific references — it must compile standalone
-// and run inside both sidebars' sandboxed iframes.
+// Shared client-side MathJax equation machinery (preprocessing + SVG→canvas→PNG
+// rendering), injected into the Docs, Slides, and Sheets SidebarJS.html by
+// BuildSidebarJS.js (compiled to SidebarMathJaxShared.js). Keep this file free of
+// project-specific references — it must compile standalone and run inside every
+// sidebar's sandboxed iframe.
+
+declare const MathJax: {
+  tex2svgPromise(equation: string, options: { display: boolean, em: number }): Promise<Element>;
+  svgStylesheet(): Element;
+};
+
+interface SharedMathJaxRenderOptions {
+  equation: string;
+  inline: boolean;
+  size: number;
+  r: number;
+  g: number;
+  b: number;
+  bgR?: number;
+  bgG?: number;
+  bgB?: number;
+}
+
+// REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in
+// parallel (e.g. 1000 equations) would freeze the browser; this caps concurrency.
+const MATHJAX_CONCURRENCY_LIMIT = 4;
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+async function blobToB64(blob: Blob) {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = err => reject(err);
+    reader.readAsDataURL(blob);
+  });
+  return dataUrl.substring(dataUrl.indexOf(",") + 1); // strip dataurl header
+}
+
+/**
+ * Render one equation to a PNG blob via MathJax: preprocess, typeset to SVG,
+ * rasterize at 5x on a canvas (optionally over a sampled background color), and
+ * export. `reportError` (each sidebar passes its Cloud Logging reporter) receives
+ * TeX syntax errors; rendering still proceeds so one bad equation can't fail a
+ * batch.
+ */
+async function renderEquationPngWithMathJax(
+  renderOptions: SharedMathJaxRenderOptions,
+  reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
+): Promise<Blob> {
+  const equationBody = prepareEquationForMathJax(renderOptions.equation);
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
+
+  const mathJaxGlobal = (window as unknown as { MathJax?: typeof MathJax }).MathJax;
+  if (!mathJaxGlobal || typeof mathJaxGlobal.tex2svgPromise !== "function") {
+    throw new Error("MathJax is still loading. Please try again in a moment.");
+  }
+
+  const result = await mathJaxGlobal.tex2svgPromise(equation, {
+    display: !renderOptions.inline,
+    em: renderOptions.size
+  });
+  const svg = result.querySelector("svg") as SVGSVGElement | null;
+  if (!svg) {
+    throw new Error("MathJax did not return an SVG element.");
+  }
+
+  // REASON: tex2svgPromise RESOLVES on TeX syntax errors, embedding the message as a
+  // red merror node — report them (with the equation) so they're debuggable.
+  const mjxErrorNode = svg.querySelector("[data-mjx-error]");
+  if (mjxErrorNode && reportError) {
+    reportError("mathjax.merror", mjxErrorNode.getAttribute("data-mjx-error") || "unknown TeX error", {
+      equation: renderOptions.equation,
+    });
+  }
+
+  // measure at the requested font size, then rasterize at 5x for quality
+  svg.classList.add("mathjax-equation-hidden-render");
+  svg.style.fontSize = `${renderOptions.size}px`;
+  document.body.appendChild(svg);
+  const width = svg.clientWidth * 5;
+  const height = svg.clientHeight * 5;
+  svg.remove();
+  svg.setAttribute("width", `${width}px`);
+  svg.setAttribute("height", `${height}px`);
+
+  const styles = mathJaxGlobal.svgStylesheet().outerHTML;
+  const svgString = new XMLSerializer().serializeToString(svg).replace("</svg>", styles + "</svg>");
+  const svgBlob = new Blob([svgString], { type: "image/svg+xml" });
+  const svgUrl = URL.createObjectURL(svgBlob);
+
+  const canvas = typeof OffscreenCanvas !== "undefined"
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement("canvas"), { width, height });
+  const ctx = canvas.getContext("2d") as CanvasRenderingContext2D | null;
+  if (!ctx) {
+    throw new Error("Could not initialize a 2D canvas for MathJax rendering.");
+  }
+
+  // REASON: when the equation text carries a highlight (background color), the
+  // server samples it into bgR/bgG/bgB; bake it into the PNG so the image matches
+  // the highlight band instead of showing the page through a transparent
+  // background. Absent -> transparent.
+  if (typeof renderOptions.bgR === "number") {
+    ctx.fillStyle = `rgb(${renderOptions.bgR},${renderOptions.bgG},${renderOptions.bgB})`;
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  try {
+    const svgImage = new Image(width, height);
+    svgImage.src = svgUrl;
+    await new Promise<void>((resolve, reject) => {
+      svgImage.onload = () => resolve();
+      svgImage.onerror = err => reject(err);
+    });
+
+    ctx.drawImage(svgImage, 0, 0);
+
+    return "convertToBlob" in canvas
+      ? await (canvas as OffscreenCanvas).convertToBlob({ type: "image/png" })
+      : await new Promise<Blob>((resolve, reject) => {
+          (canvas as HTMLCanvasElement).toBlob(blob => {
+            if (blob) {
+              resolve(blob);
+            } else {
+              reject(new Error("Could not convert MathJax canvas to a PNG blob."));
+            }
+          }, "image/png");
+        });
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
+}
 
 function hasNonAsciiText(value: string) {
   return value.split("").some(char => char.charCodeAt(0) > 0x7F);

--- a/SidebarMathJaxShared.ts
+++ b/SidebarMathJaxShared.ts
@@ -1,0 +1,81 @@
+/// <reference lib="dom" />
+
+// Shared client-side MathJax equation preprocessing, injected into the Docs and
+// Slides SidebarJS.html by BuildSidebarJS.js (compiled to SidebarMathJaxShared.js).
+// Keep this file free of project-specific references — it must compile standalone
+// and run inside both sidebars' sandboxed iframes.
+
+function hasNonAsciiText(value: string) {
+  return value.split("").some(char => char.charCodeAt(0) > 0x7F);
+}
+
+// REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
+// LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
+// content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
+// puts environments on their own lines). Only the remaining depth-0 newlines mean
+// "new output line" — the sidebar's shift+enter contract. An explicit \\ followed
+// by a newline collapses to a single row break instead of adding an empty line.
+function replaceNewlinesDepthAware(equation: string) {
+  let depth = 0;
+  let result = "";
+  for (let i = 0; i < equation.length; i++) {
+    const ch = equation.charAt(i);
+    if (ch === "\\") {
+      if (equation.startsWith("\\begin", i)) {
+        depth++;
+      } else if (equation.startsWith("\\end", i)) {
+        depth = Math.max(0, depth - 1);
+      }
+      // copy escape pairs atomically so \\ never half-matches the checks above
+      result += ch;
+      if (i + 1 < equation.length) {
+        result += equation.charAt(i + 1);
+        i++;
+      }
+      continue;
+    }
+    if (ch === "\n" || ch === "\r" || ch === "\u000B") {
+      const upcoming = equation.slice(i + 1).replace(/^[\s\u000B]+/, "");
+      const cosmeticBoundary =
+        depth > 0 ||
+        upcoming.startsWith("\\begin") ||
+        /\\end\s*\{[^{}]*\}\s*$/.test(result);
+      if (cosmeticBoundary) {
+        result += " ";
+      } else if (/\\\\\s*$/.test(result)) {
+        result += " "; // already ends with an explicit row break; don't double it
+      } else {
+        result += "\\\\";
+      }
+      continue;
+    }
+    result += ch;
+  }
+  return result;
+}
+
+/**
+ * Full preprocessing chain applied to an equation before MathJax sees it.
+ * Returns the equation body (color prefix is applied by the caller).
+ */
+function prepareEquationForMathJax(rawEquation: string) {
+  const preprocessed = rawEquation
+    // Unicode text inside \mbox/\mathrm needs \text for MathJax's textmacros path
+    .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    // REASON: renders/derenders performed while the pre-2026-07 backslash collapse
+    // was live permanently stripped one backslash from "\\\hline" in user docs,
+    // leaving the exact 2-backslash signature "\\hline" (row break + literal
+    // "hline" text). Repair it; a pristine 3-backslash run can't match this regex.
+    .replace(/(^|[^\\])\\\\hline/g, "$1\\\\ \\hline");
+  let equationBody = replaceNewlinesDepthAware(preprocessed);
+  // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
+  // equations (which the sidebar instructions promise, and which Codecogs honors)
+  // silently rendered on one line. Wrap top-level \\ in gathered to restore the
+  // promised line breaks. Equations that already use an environment (align, table,
+  // gathered, ...) are left alone — their \\ belongs to that environment.
+  if (/\\\\/.test(equationBody) && !/\\begin\s*\{/.test(equationBody)) {
+    equationBody = `\\begin{gathered}${equationBody}\\end{gathered}`;
+  }
+  return equationBody;
+}

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -382,7 +382,7 @@ function findAllClientRenderEquationsInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
@@ -602,6 +602,34 @@ function getBgRgbColor(textRange: GoogleAppsScript.Slides.TextRange, slideNum: n
   ];
 }
 
+// REASON: rendering deletes the equation's text box when the equation was its only
+// content — taking the box's fill with it — and oversized equations overflow the
+// box anyway (user report: image doesn't fit, box gone, background lost). Bake the
+// box/cell SOLID fill into the image when the text has no explicit highlight.
+// Gradient/image fills can't be represented by one color; those stay transparent.
+function getShapeFillRgbColor(element: PageElement, slideNum: number): [number, number, number] | null {
+  try {
+    const fill = element.getFill();
+    if (!fill) return null;
+    const solid = fill.getSolidFill();
+    if (!solid) return null;
+    let color = solid.getColor();
+    if (color.getColorType() !== SlidesApp.ColorType.RGB) {
+      const slide = IntegratedApp.getBody()[slideNum];
+      color = slide.getColorScheme().getConcreteColor(color.asThemeColor().getThemeColorType());
+    }
+    return [
+      color.asRgbColor().getRed(),
+      color.asRgbColor().getGreen(),
+      color.asRgbColor().getBlue(),
+    ];
+  } catch (err) {
+    // elements without a fill API (or transparent fills) simply stay transparent
+    console.log("getShapeFillRgbColor: no usable fill; keeping transparent.", String(err));
+    return null;
+  }
+}
+
 function unwrapEQ(element: PageElement) {
   let textValue: GoogleAppsScript.Slides.TextRange | null = null;
   // test if it's a text box (table cells work)
@@ -745,7 +773,7 @@ function findClientRenderEquationInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -1226,7 +1226,15 @@ function derenderImage(image: GoogleAppsScript.Slides.Image, defaultDelim: AutoL
   if (!origURL) return Common.DerenderResult.NullUrl;
 
   Common.debugLog("Original URL from image", origURL);
-  const result = Common.derenderEquation(origURL, IntegratedApp);
+  // REASON: same escape()-era %uXXXX guard as Docs — decodeURIComponent rejects those
+  // legacy URLs (URIError) and an uncaught throw crashed the whole derender pass.
+  let result: ReturnType<typeof Common.derenderEquation>;
+  try {
+    result = Common.derenderEquation(origURL, IntegratedApp);
+  } catch (err) {
+    console.error("derenderImage: failed to decode equation URL; skipping image.", String(err), " url=", String(origURL).substring(0, 500));
+    return Common.DerenderResult.InvalidUrl;
+  }
   if (!result) return Common.DerenderResult.InvalidUrl;
   const { delim: newDelim, origEq } = result;
   const delim = newDelim || defaultDelim;

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -383,16 +383,7 @@ function findAllClientRenderEquationsInTextElement(
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
-    const clientEquation = decodeURIComponent(
-      equationOriginal
-        // REASON: restore the reEncode newline marker to a literal \v (Slides'
-        // shift-enter character) instead of pre-converting to "\\". The client
-        // decides per-position whether a newline is a row break or cosmetic paste
-        // formatting (inside environments), and derender round-trips stay intact.
-        .split("%5C%5C%5C%5C%20").join("%0B")
-        // legacy doubled row breaks, same collapse as the Codecogs path
-        .split("%5C%5C%5C%5C").join("%5C%5C")
-    );
+    const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
 
     results.push({
       size,
@@ -732,16 +723,7 @@ function findClientRenderEquationInTextElement(
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
-    const clientEquation = decodeURIComponent(
-      equationOriginal
-        // REASON: restore the reEncode newline marker to a literal \v (Slides'
-        // shift-enter character) instead of pre-converting to "\\". The client
-        // decides per-position whether a newline is a row break or cosmetic paste
-        // formatting (inside environments), and derender round-trips stay intact.
-        .split("%5C%5C%5C%5C%20").join("%0B")
-        // legacy doubled row breaks, same collapse as the Codecogs path
-        .split("%5C%5C%5C%5C").join("%5C%5C")
-    );
+    const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
 
     return {
       size,

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -383,7 +383,16 @@ function findAllClientRenderEquationsInTextElement(
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
-    const clientEquation = decodeURIComponent(equationOriginal.split("%5C%5C%5C%5C").join("%5C%5C"));
+    const clientEquation = decodeURIComponent(
+      equationOriginal
+        // REASON: restore the reEncode newline marker to a literal \v (Slides'
+        // shift-enter character) instead of pre-converting to "\\". The client
+        // decides per-position whether a newline is a row break or cosmetic paste
+        // formatting (inside environments), and derender round-trips stay intact.
+        .split("%5C%5C%5C%5C%20").join("%0B")
+        // legacy doubled row breaks, same collapse as the Codecogs path
+        .split("%5C%5C%5C%5C").join("%5C%5C")
+    );
 
     results.push({
       size,
@@ -723,7 +732,16 @@ function findClientRenderEquationInTextElement(
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
-    const clientEquation = decodeURIComponent(equationOriginal.split("%5C%5C%5C%5C").join("%5C%5C"));
+    const clientEquation = decodeURIComponent(
+      equationOriginal
+        // REASON: restore the reEncode newline marker to a literal \v (Slides'
+        // shift-enter character) instead of pre-converting to "\\". The client
+        // decides per-position whether a newline is a row break or cosmetic paste
+        // formatting (inside environments), and derender round-trips stay intact.
+        .split("%5C%5C%5C%5C%20").join("%0B")
+        // legacy doubled row breaks, same collapse as the Codecogs path
+        .split("%5C%5C%5C%5C").join("%5C%5C")
+    );
 
     return {
       size,

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -25,6 +25,9 @@ interface SlidesClientRenderOptions {
   r: number;
   g: number;
   b: number;
+  bgR?: number;
+  bgG?: number;
+  bgB?: number;
   delim: AutoLatexCommon.Delimiter;
   equation: string;
   equationLinkEncoded: string;
@@ -379,6 +382,7 @@ function findAllClientRenderEquationsInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
@@ -391,6 +395,7 @@ function findAllClientRenderEquationsInTextElement(
       r: textColor[0],
       g: textColor[1],
       b: textColor[2],
+      ...(bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}),
       delim: renderOptions.delim,
       equation: clientEquation,
       equationLinkEncoded: encodeURIComponent(clientEquation),
@@ -576,6 +581,27 @@ function getRgbColor(textRange: GoogleAppsScript.Slides.TextRange, slideNum: num
   return [red, green, blue];
 }
 
+// REASON: equations inside highlighted text render as transparent PNGs, which show
+// the slide/shape background through the highlight band and made light-colored
+// equations invisible (user report). Sample the text's highlight color so the
+// shared canvas renderer bakes it into the image; null (no highlight) keeps the
+// image transparent, which composites correctly over shape fills.
+function getBgRgbColor(textRange: GoogleAppsScript.Slides.TextRange, slideNum: number): [number, number, number] | null {
+  let backgroundColor = textRange.getTextStyle().getBackgroundColor();
+  if (backgroundColor == null) {
+    return null;
+  }
+  if (backgroundColor.getColorType() !== SlidesApp.ColorType.RGB) {
+    const slide = IntegratedApp.getBody()[slideNum];
+    backgroundColor = slide.getColorScheme().getConcreteColor(backgroundColor.asThemeColor().getThemeColorType());
+  }
+  return [
+    backgroundColor.asRgbColor().getRed(),
+    backgroundColor.asRgbColor().getGreen(),
+    backgroundColor.asRgbColor().getBlue(),
+  ];
+}
+
 function unwrapEQ(element: PageElement) {
   let textValue: GoogleAppsScript.Slides.TextRange | null = null;
   // test if it's a text box (table cells work)
@@ -719,6 +745,7 @@ function findClientRenderEquationInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
+    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
@@ -731,6 +758,7 @@ function findClientRenderEquationInTextElement(
       r: textColor[0],
       g: textColor[1],
       b: textColor[2],
+      ...(bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}),
       delim: renderOptions.delim,
       equation: clientEquation,
       equationLinkEncoded: encodeURIComponent(clientEquation),
@@ -1220,14 +1248,29 @@ function editEquations(sizeRaw: string, delimiter: string, renderer: string = "a
   Common.debugLog("selection Type is: " + selectionType);
 
   if (selectionType == SlidesApp.SelectionType.PAGE_ELEMENT) {
-    // if they're selecting an image inside a group, the image is the second element in the selection
-    const image = selection.getPageElementRange().getPageElements().find(el => el.getPageElementType() === SlidesApp.PageElementType.IMAGE)?.asImage();
-    if (image) {
-      return derenderImage(image, defaultDelim, currentPage);
-    } else {
-      return Common.DerenderResult.NonExistentElement;
+    // REASON: derender EVERY selected image, not just the first — shift-clicking
+    // several equations and hitting De-render only restored one (user report).
+    // Non-ALE images (no parseable title JSON) are skipped by derenderImage.
+    const images = selection.getPageElementRange().getPageElements()
+      .filter(el => el.getPageElementType() === SlidesApp.PageElementType.IMAGE)
+      .map(el => el.asImage());
+    if (images.length === 0) {
+      return { result: Common.DerenderResult.NonExistentElement, successCount: 0 };
     }
+    let successCount = 0;
+    let lastFailureResult = Common.DerenderResult.InvalidUrl;
+    for (const image of images) {
+      const result = derenderImage(image, defaultDelim, currentPage);
+      if (result === Common.DerenderResult.Success) {
+        successCount++;
+      } else {
+        lastFailureResult = result;
+      }
+    }
+    return successCount > 0
+      ? { result: Common.DerenderResult.Success, successCount }
+      : { result: lastFailureResult, successCount: 0 };
   } else {
-    return Common.DerenderResult.CursorNotFound;
+    return { result: Common.DerenderResult.CursorNotFound, successCount: 0 };
   }
 }

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -123,7 +123,16 @@ async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
   const equationForMathJax = renderOptions.equation
     .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
     .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+  let equationBody = equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+  // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
+  // equations (which the sidebar instructions promise, and which Codecogs honors)
+  // silently rendered on one line. Wrap top-level \\ in gathered to restore the
+  // promised line breaks. Equations that already use an environment (align, table,
+  // gathered, ...) are left alone — their \\ belongs to that environment.
+  if (/\\\\/.test(equationBody) && !/\\begin\s*\{/.test(equationBody)) {
+    equationBody = `\\begin{gathered}${equationBody}\\end{gathered}`;
+  }
+  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
 
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
     throw new Error("MathJax is still loading. Please try again in a moment.");

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -16,6 +16,9 @@ interface Window {
 
 declare const MathJax: MathJaxApi;
 
+// implemented in ../SidebarMathJaxShared.ts, injected ahead of this file by BuildSidebarJS.js
+declare function prepareEquationForMathJax(equation: string): string;
+
 // REASON: mirrors the Docs sidebar's client-error reporting so MathJax failures in
 // Slides reach Cloud Logging with the offending equation; without it they vanished
 // in the sandboxed iframe. Deduped per session to keep error-path ingestion tiny.
@@ -115,73 +118,10 @@ async function blobToB64(blob: Blob) {
   return dataUrl.substring(dataUrl.indexOf(",") + 1);
 }
 
-function hasNonAsciiText(value: string) {
-  return value.split("").some(char => char.charCodeAt(0) > 0x7F);
-}
-
-// REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
-// LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
-// content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
-// puts environments on their own lines). Only the remaining depth-0 newlines mean
-// "new output line" — the sidebar's shift+enter contract. An explicit \\ followed
-// by a newline collapses to a single row break instead of adding an empty line.
-function replaceNewlinesDepthAware(equation: string) {
-  let depth = 0;
-  let result = "";
-  for (let i = 0; i < equation.length; i++) {
-    const ch = equation.charAt(i);
-    if (ch === "\\") {
-      if (equation.startsWith("\\begin", i)) {
-        depth++;
-      } else if (equation.startsWith("\\end", i)) {
-        depth = Math.max(0, depth - 1);
-      }
-      // copy escape pairs atomically so \\ never half-matches the checks above
-      result += ch;
-      if (i + 1 < equation.length) {
-        result += equation.charAt(i + 1);
-        i++;
-      }
-      continue;
-    }
-    if (ch === "\n" || ch === "\r" || ch === "\u000B") {
-      const upcoming = equation.slice(i + 1).replace(/^[\s\u000B]+/, "");
-      const cosmeticBoundary =
-        depth > 0 ||
-        upcoming.startsWith("\\begin") ||
-        /\\end\s*\{[^{}]*\}\s*$/.test(result);
-      if (cosmeticBoundary) {
-        result += " ";
-      } else if (/\\\\\s*$/.test(result)) {
-        result += " "; // already ends with an explicit row break; don't double it
-      } else {
-        result += "\\\\";
-      }
-      continue;
-    }
-    result += ch;
-  }
-  return result;
-}
-
 async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
-  const equationForMathJax = renderOptions.equation
-    .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    // REASON: renders/derenders performed while the pre-2026-07 backslash collapse
-    // was live permanently stripped one backslash from "\\\hline" in user docs,
-    // leaving the exact 2-backslash signature "\\hline" (row break + literal
-    // "hline" text). Repair it; a pristine 3-backslash run can't match this regex.
-    .replace(/(^|[^\\])\\\\hline/g, "$1\\\\ \\hline");
-  let equationBody = replaceNewlinesDepthAware(equationForMathJax);
-  // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
-  // equations (which the sidebar instructions promise, and which Codecogs honors)
-  // silently rendered on one line. Wrap top-level \\ in gathered to restore the
-  // promised line breaks. Equations that already use an environment (align, table,
-  // gathered, ...) are left alone — their \\ belongs to that environment.
-  if (/\\\\/.test(equationBody) && !/\\begin\s*\{/.test(equationBody)) {
-    equationBody = `\\begin{gathered}${equationBody}\\end{gathered}`;
-  }
+  // preprocessing (mbox/mathrm unicode, damaged-hline repair, depth-aware
+  // newlines, gathered wrap) lives in ../SidebarMathJaxShared.ts
+  const equationBody = prepareEquationForMathJax(renderOptions.equation);
   const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
 
   if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -119,11 +119,61 @@ function hasNonAsciiText(value: string) {
   return value.split("").some(char => char.charCodeAt(0) > 0x7F);
 }
 
+// REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
+// LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
+// content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
+// puts environments on their own lines). Only the remaining depth-0 newlines mean
+// "new output line" — the sidebar's shift+enter contract. An explicit \\ followed
+// by a newline collapses to a single row break instead of adding an empty line.
+function replaceNewlinesDepthAware(equation: string) {
+  let depth = 0;
+  let result = "";
+  for (let i = 0; i < equation.length; i++) {
+    const ch = equation.charAt(i);
+    if (ch === "\\") {
+      if (equation.startsWith("\\begin", i)) {
+        depth++;
+      } else if (equation.startsWith("\\end", i)) {
+        depth = Math.max(0, depth - 1);
+      }
+      // copy escape pairs atomically so \\ never half-matches the checks above
+      result += ch;
+      if (i + 1 < equation.length) {
+        result += equation.charAt(i + 1);
+        i++;
+      }
+      continue;
+    }
+    if (ch === "\n" || ch === "\r" || ch === "\u000B") {
+      const upcoming = equation.slice(i + 1).replace(/^[\s\u000B]+/, "");
+      const cosmeticBoundary =
+        depth > 0 ||
+        upcoming.startsWith("\\begin") ||
+        /\\end\s*\{[^{}]*\}\s*$/.test(result);
+      if (cosmeticBoundary) {
+        result += " ";
+      } else if (/\\\\\s*$/.test(result)) {
+        result += " "; // already ends with an explicit row break; don't double it
+      } else {
+        result += "\\\\";
+      }
+      continue;
+    }
+    result += ch;
+  }
+  return result;
+}
+
 async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
   const equationForMathJax = renderOptions.equation
     .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
-    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match);
-  let equationBody = equationForMathJax.replace(/\n|\r|\r\n/g, "\\\\");
+    .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
+    // REASON: renders/derenders performed while the pre-2026-07 backslash collapse
+    // was live permanently stripped one backslash from "\\\hline" in user docs,
+    // leaving the exact 2-backslash signature "\\hline" (row break + literal
+    // "hline" text). Repair it; a pristine 3-backslash run can't match this regex.
+    .replace(/(^|[^\\])\\\\hline/g, "$1\\\\ \\hline");
+  let equationBody = replaceNewlinesDepthAware(equationForMathJax);
   // REASON: MathJax v3 ignores \\ outside an environment, so shift+enter multi-line
   // equations (which the sidebar instructions promise, and which Codecogs honors)
   // silently rendered on one line. Wrap top-level \\ in gathered to restore the

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -47,6 +47,9 @@ interface SlidesClientRenderOptions {
   r: number;
   g: number;
   b: number;
+  bgR?: number;
+  bgG?: number;
+  bgB?: number;
   delim: AutoLatexCommon.Delimiter;
   equation: string;
   equationLinkEncoded: string;
@@ -400,15 +403,12 @@ function editText(){
   const {sizeRaw, delimiter, renderer} = getCurrentSettings();
   google.script.run
     .withSuccessHandler(
-      function(returnSuccess, element) {
+      function(returnSuccess: { result: AutoLatexCommon.DerenderResult, successCount: number }, element) {
         $("#loading").html('');
         clearInterval(runDots);
         element.disabled = false;
-        $("#loading").html("Status: " + "1"             + " equation replaced.");
-        if(returnSuccess < 0)
-          $("#loading").html("Status: " + "No"          + " equations replaced.");
-          
-          switch (returnSuccess) {
+
+          switch (returnSuccess.result) {
             case AutoLatexCommon.DerenderResult.InvalidUrl:
               showError("Cannot retrieve equation. The equation may not have been rendered by Auto-LaTeX.", "Status: Error, please ensure link is still on equation.");
               break;
@@ -419,15 +419,17 @@ function editText(){
               showError("Cannot retrieve equation. Is your cursor before an Auto-LaTeX rendered equation?", "Status: Error, please move cursor before inline equation.");
               break;
             case AutoLatexCommon.DerenderResult.NonExistentElement:
-              showError("Cannot insert text here. Is your cursor before an equation?", "Status: Error, please move cursor before equation.");
+              showError("No image found in your selection. Click the rendered equation image (shift-click to select several) and try again.", "Status: Error, please select the equation image.");
               break;
             case AutoLatexCommon.DerenderResult.CursorNotFound:
-              showError("Cannot find a cursor/equation. Please click before an equation.", "Status: Error, please move cursor before equation.");
+              showError("Nothing is selected. Click the rendered equation image (shift-click to select several) and try again.", "Status: Error, please select the equation image.");
               break;
             case AutoLatexCommon.DerenderResult.Success:
-            default:
-              $("#loading").html("Status: 1 equation de-rendered.");
+            default: {
+              const n = returnSuccess.successCount || 1;
+              $("#loading").html(`Status: ${n} equation${n === 1 ? "" : "s"} de-rendered.`);
               break;
+            }
           }
       })
     .withFailureHandler(

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -16,8 +16,6 @@ interface Window {
 
 declare const MathJax: MathJaxApi;
 
-// implemented in ../SidebarMathJaxShared.ts, injected ahead of this file by BuildSidebarJS.js
-declare function prepareEquationForMathJax(equation: string): string;
 
 // REASON: mirrors the Docs sidebar's client-error reporting so MathJax failures in
 // Slides reach Cloud Logging with the offending equation; without it they vanished
@@ -89,115 +87,19 @@ function makeSlidesRenderStatusText(renderCount: number) {
   return `Status: ${renderCount} equations rendered`;
 }
 
-// REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in parallel
-// (e.g. 1000 equations) would freeze the browser. This limits concurrency to a safe number.
-const MATHJAX_CONCURRENCY_LIMIT = 4;
-
-async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-
-  async function worker() {
-    while (nextIndex < items.length) {
-      const index = nextIndex++;
-      results[index] = await fn(items[index]);
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
-  return results;
-}
-
-async function blobToB64(blob: Blob) {
-  const dataUrl = await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result as string);
-    reader.onerror = err => reject(err);
-    reader.readAsDataURL(blob);
-  });
-  return dataUrl.substring(dataUrl.indexOf(",") + 1);
-}
+// Shared MathJax machinery (mapWithConcurrency, blobToB64, MATHJAX_CONCURRENCY_LIMIT,
+// renderEquationPngWithMathJax) is implemented in ../SidebarMathJaxShared.ts and
+// injected ahead of this file by BuildSidebarJS.js.
+declare const MATHJAX_CONCURRENCY_LIMIT: number;
+declare function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]>;
+declare function blobToB64(blob: Blob): Promise<string>;
+declare function renderEquationPngWithMathJax(
+  renderOptions: { equation: string; inline: boolean; size: number; r: number; g: number; b: number; bgR?: number; bgG?: number; bgB?: number },
+  reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
+): Promise<Blob>;
 
 async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
-  // preprocessing (mbox/mathrm unicode, damaged-hline repair, depth-aware
-  // newlines, gathered wrap) lives in ../SidebarMathJaxShared.ts
-  const equationBody = prepareEquationForMathJax(renderOptions.equation);
-  const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
-
-  if (!window.MathJax || typeof window.MathJax.tex2svgPromise !== "function") {
-    throw new Error("MathJax is still loading. Please try again in a moment.");
-  }
-
-  const result = await window.MathJax.tex2svgPromise(equation, {
-    display: !renderOptions.inline,
-    em: renderOptions.size
-  });
-  const svg: SVGSVGElement | null = result.querySelector("svg");
-  if (!svg) {
-    throw new Error("MathJax did not return an SVG element.");
-  }
-
-  // REASON: tex2svgPromise RESOLVES on TeX syntax errors, embedding the message as a
-  // red merror node — so bad equations were silently inserted as error images with no
-  // trace in Cloud Logging. Report them (with the equation) so they're debuggable;
-  // rendering still proceeds so one bad equation can't fail the whole batch.
-  const mjxErrorNode = svg.querySelector("[data-mjx-error]");
-  if (mjxErrorNode) {
-    reportMathJaxClientError("mathjax.merror", mjxErrorNode.getAttribute("data-mjx-error") || "unknown TeX error", {
-      equation: renderOptions.equation,
-    });
-  }
-
-  svg.classList.add("mathjax-equation-hidden-render");
-  svg.style.fontSize = `${renderOptions.size}px`;
-  document.body.appendChild(svg);
-
-  const width = svg.clientWidth * 5;
-  const height = svg.clientHeight * 5;
-
-  svg.remove();
-  svg.setAttribute("width", `${width}px`);
-  svg.setAttribute("height", `${height}px`);
-
-  const styles = MathJax.svgStylesheet().outerHTML;
-  const svgString = new XMLSerializer().serializeToString(svg).replace("</svg>", styles + "</svg>");
-  const svgBlob = new Blob([svgString], {
-    type: "image/svg+xml"
-  });
-  const svgUrl = URL.createObjectURL(svgBlob);
-
-  const canvas = typeof OffscreenCanvas !== "undefined"
-    ? new OffscreenCanvas(width, height)
-    : Object.assign(document.createElement("canvas"), { width, height });
-  const ctx = canvas.getContext("2d");
-  if (!ctx) {
-    throw new Error("Could not initialize a 2D canvas for MathJax rendering.");
-  }
-
-  try {
-    const svgImage = new Image(width, height);
-    svgImage.src = svgUrl;
-    await new Promise<void>((resolve, reject) => {
-      svgImage.onload = () => resolve();
-      svgImage.onerror = err => reject(err);
-    });
-
-    ctx.drawImage(svgImage, 0, 0);
-
-    return "convertToBlob" in canvas
-      ? await canvas.convertToBlob({ type: "image/png" })
-      : await new Promise<Blob>((resolve, reject) => {
-          (canvas as HTMLCanvasElement).toBlob(blob => {
-            if (blob) {
-              resolve(blob);
-            } else {
-              reject(new Error("Could not convert MathJax canvas to a PNG blob."));
-            }
-          }, "image/png");
-        });
-  } finally {
-    URL.revokeObjectURL(svgUrl);
-  }
+  return renderEquationPngWithMathJax(renderOptions, reportMathJaxClientError);
 }
 
 /**

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -44,6 +44,11 @@ declare namespace AutoLatexCommon {
          */
         reEncode(equation: string, app: IntegratedApp): string;
 
+        /**
+         * Decode a reEncoded equation for the client-side (MathJax) renderer.
+         */
+        getClientEquation(equationOriginal: string, app: IntegratedApp): string;
+
         renderEquation(equationOriginal: string, renderOptions: RenderOptions): RenderEquationResult;
 
         renderEquation(equationOriginal: string, quality: number, delim: Delimiter, isInline: boolean, red: number, green: number, blue: number): RenderEquationResult;

--- a/types/common-types/index.d.ts
+++ b/types/common-types/index.d.ts
@@ -82,6 +82,13 @@ declare namespace AutoLatexCommon {
 
         b: number;
 
+        /** Sampled text background (highlight) color; absent -> transparent image. */
+        bgR?: number;
+
+        bgG?: number;
+
+        bgB?: number;
+
         delim: Delimiter;
 
         equation: string;


### PR DESCRIPTION
## Issues fixed (TL;DR)

1. **Shift+enter multi-line equations rendered on one line** via the MathJax renderer — MathJax v3 ignores top-level `\\`; only Codecogs ever honored it.
2. **Pasted LaTeX with cosmetic newlines rendered mangled** — every line break became a row break, so matrix products / multi-environment equations stacked vertically (user report).
3. **Docs damaged by the old backslash collapse** rendered the literal word "hline" in tables — now transparently repaired at render time.
4. **Very long equations hung or 400'd on server renderers** behind a guessed "too long" message — now skipped with an explicit logged error naming the real cause.

## Details

### Depth-aware newline handling
`renderMathJaxEquation` (Docs + Slides) now classifies each newline: inside a `\begin{...}\end{...}` environment, or at depth 0 immediately before `\begin`/after `\end{...}`, it's cosmetic paste formatting → becomes a space; any other depth-0 newline keeps the sidebar's shift+enter row-break contract; an explicit `\\` followed by a newline collapses to a single break. To enable this, `buildClientRenderResponse` hands the client literal newline characters (the reEncode marker → `\r` for Docs, `\v` for Slides) instead of pre-converting to `\\` — which also makes derender round-trips byte-identical to the original doc text.

### Top-level `\\` wrapped in `gathered`
Equations containing top-level `\\` and no `\begin{...}` are wrapped in `\begin{gathered}...\end{gathered}` so MathJax honors the line breaks. Environment-using equations are untouched.

### Damaged-`\\hline` repair
Renders/derenders performed while the pre-#62 backslash collapse was live permanently stripped one backslash from `\\\hline` in user docs, leaving the exact 2-backslash signature `\\hline` (row break + literal "hline" text). The client repairs that signature to `\\ \hline` before rendering; a pristine 3-backslash run cannot match the regex.

### Long-URL guard
`Common.renderEquation` throws an explicit "Equation URL too long for <renderer> (N chars > 8000)" before fetching, so the log states the real cause (with the full equation, via #62's error logging) and the next renderer is tried instead of hanging on a doomed request.

## Verification
10-case harness driving the *compiled* sidebar transform extracted from the built `SidebarJS.html`: pasted matrix collapses to one line; shift+enter 4-line equation stays 4 lines; `\\`+newline doesn't double-break; damaged and pristine `\hline` tables both render; align/matrix/single-line/tag/dfrac/split regressions unchanged.

## Release
Docs **v83** cut (pinned Common@6, `developmentMode: false`) and deployed; Marketplace flip 82→83 pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)