### PR TITLE
Fix single-dollar rendering: empty-eq skip, prose mis-pairing, MathJax v3 crash

### DIFF
--- a/BuildSidebarJS.js
+++ b/BuildSidebarJS.js
@@ -16,14 +16,19 @@ function getMathJaxSetup() {
   //   - caption becomes a centered text row inside the gathered; label/centering/
   //     noindent/vspace are display no-ops
   //   - toprule/midrule/bottomrule cover ChatGPT-generated booktabs tables
-  // configmacros (which reads 'macros'/'environments') is already in tex-svg's default
-  // package set, so only 'color' needs explicit loading. Verified against MathJax 3.2.2:
-  // both user-reported table equations plus align/plain-math regressions all render.
+  // configmacros (which reads 'macros'/'environments') and textmacros are already in
+  // tex-svg's default package set, so only 'color' needs explicit loading.
+  //
+  // REASON: do not put the combined `tex-svg` component in loader.load. The component
+  // is loaded directly by the script tag below; asking the loader to load it again
+  // re-enters configuration startup. In the Google Apps Script iframe that exposed
+  // MathJax v3's `Package` getter collision and aborted every client render before
+  // tex2svgPromise existed.
   return `
 window.MathJax = {
-  loader: { load: ['tex-svg', '[tex]/color', '[tex]/textmacros'] },
+  loader: { load: ['[tex]/color'] },
   tex: {
-    packages: { '[+]': ['color', 'textmacros'] },
+    packages: { '[+]': ['color'] },
     macros: {
       centering: '',
       caption: ['\\\\\\\\[0.5em]\\\\text{#1}', 1],
@@ -58,14 +63,19 @@ window.MathJax = {
 function wrapJS(sidebarJS, includeMathJax, sharedJS) {
   const mathJaxSetup = includeMathJax ? getMathJaxSetup() : "";
   const sharedBlock = includeMathJax && sharedJS ? `\n${sharedJS}` : "";
-  // REASON: crossorigin="anonymous" makes the browser surface real error
+  // REASON: pin MathJax 4.1.2. The prior v3 bundle crashes during configuration in
+  // Google Apps Script sidebars with "Cannot set property Package ... which has only
+  // a getter"; MathJax v4 fixes that exact getter-only configuration bug. Keep the
+  // version explicit so a future CDN release cannot silently change rendering.
+  //
+  // crossorigin="anonymous" makes the browser surface real error
   // details (message/filename/lineno/stack) in window.onerror for this
   // cross-origin script. Without it, every MathJax failure inside the sandboxed
   // iframe gets reported as the opaque "Script error." — which dominated our
   // Cloud Logging signal. The jsdelivr CDN serves the proper
   // Access-Control-Allow-Origin header, so this is purely an opt-in on our side.
   const mathJaxScript = includeMathJax
-    ? '\n<script type="text/javascript" id="MathJax-script" async crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>'
+    ? '\n<script type="text/javascript" id="MathJax-script" async crossorigin="anonymous" src="https://cdn.jsdelivr.net/npm/mathjax@4.1.2/tex-svg.js"></script>'
     : "";
 
   return `<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -784,7 +784,7 @@ function buildClientRenderResponse(textElement, startElement, equationOriginal, 
     // which already resumes from endElement. (A previous fix re-read the named range's span here and
     // passed the unit tests, but that span still starts at the opening `$`, so it mis-paired in
     // production — confirmed via the Cloud Logging trace for a live user.)
-    var nextStartElement = endElement || namedRange.getRange().getRangeElements().slice(-1)[0];
+    var nextStartElement = endElement;
     var clientRenderOptions = __assign(__assign({}, coloredRenderOptions), { size: size, rangeId: namedRange.getId(), equation: clientEquation, equationLinkEncoded: encodeURIComponent(clientEquation) });
     return {
         status: 2 /* DocsEquationRenderStatus.ClientRender */,

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -416,7 +416,17 @@ function tryAutoMergeMultiParagraphEquation(body, startParaIdx, endParaIdx) {
         // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
         // See newlineCharacter comment near top of this file.
         startPara.editAsText().appendText("\r" + text);
-        nextPara.removeFromParent();
+        // REASON: Docs forbids deleting the final paragraph of a section — removeFromParent()
+        // throws "Can't remove the last paragraph in a document section" (seen in prod when an
+        // equation spans into the section's last paragraph). Its text is already merged into
+        // startPara, so when nextPara is that final paragraph, empty it in place instead of
+        // removing it; a trailing empty paragraph is harmless and the scan re-runs from scratch.
+        if (startParaIdx + 1 >= body.getNumChildren() - 1) {
+            nextPara.clear();
+        }
+        else {
+            nextPara.removeFromParent();
+        }
     }
     return { success: true, reason: "Merged " + numToMerge + " paragraph(s) with line breaks" };
 }

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -597,10 +597,11 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
             }
         };
     }
-    // REASON: the MathJax path defers removal, so buildClientRenderResponse must return
-    // a post-NamedRange-mutation cursor. Do not pass either delimiter RangeElement through:
-    // adding the named range can make both pre-mutation search results stale.
-    return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
+    // REASON: pass endElement (the closing-delimiter findText result) so the deferred MathJax path
+    // can resume the scan strictly after this equation. Resuming from the equation span instead
+    // (which starts at the opening delimiter) makes findText re-find this equation's own closing
+    // `$` and pair it forward — see buildClientRenderResponse.
+    return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions, endElement);
 }
 function getEquation(rangeElement, delimiters) {
     var textElement = rangeElement.getElement().asText();
@@ -708,7 +709,7 @@ function clientRenderComplete(equations) {
  * @param {integer} defaultSize  The default/previous size of the text, in case size is null.
  * @param {string}  delim[6]     The text delimiters and regex delimiters for start and end in that order, and offset from front and back.
  */
-function findEquationAndPlaceImage(startElement, renderOptions) {
+function findEquationAndPlaceImage(startElement, renderOptions, endElement) {
     Common.reportDeltaTime(411);
     Common.reportDeltaTime(413);
     // GET VARIABLES
@@ -739,7 +740,7 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     // REASON: Explicit MathJax and Automatic both render on the client first.
     // Automatic falls back to server renderers from the sidebar only if MathJax fails.
     if (renderOptions.clientRender || renderOptions.autoFallbackToClient) {
-        return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
+        return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size, endElement);
     }
     var _b = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions), resp = _b.resp, renderer = _b.renderer, worked = _b.worked, authorizationError = _b.authorizationError;
     if (worked > Common.capableRenderers || !resp || !renderer)
@@ -754,7 +755,7 @@ function findEquationAndPlaceImage(startElement, renderOptions) {
     Common.reportDeltaTime(517);
     return placeImage(startElement, resp.getBlob(), renderer, equationOriginal, size, renderOptions.delim);
 }
-function buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size) {
+function buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size, endElement) {
     // REASON: reEncode turns each in-equation newline into an encoded four-backslash
     // marker ("%5C%5C%5C%5C%20"), which must collapse back to a "\\ " row break for the
     // client renderer. Collapse it in ENCODED space (exactly like the Codecogs path in
@@ -769,16 +770,21 @@ function buildClientRenderResponse(textElement, startElement, equationOriginal, 
     var range = doc.newRange()
         .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
         .build();
-    // save this range for later
+    // save this range for later (used by clientRenderComplete to place the image)
     var namedRange = doc.addNamedRange("ale-equation-range", range);
-    // REASON: addNamedRange mutates the Docs structure and can invalidate every
-    // RangeElement obtained before it, including startElement and the closing
-    // delimiter from findPos. Re-read the persisted range after the mutation and
-    // use that fresh whole-equation range as findText's continuation cursor. Its
-    // inclusive end is the closing delimiter, so the next result is the following
-    // equation's opening delimiter rather than the closing delimiter again.
-    var persistedRangeElements = namedRange.getRange().getRangeElements();
-    var nextStartElement = persistedRangeElements[persistedRangeElements.length - 1];
+    // REASON: resume the scan from the CLOSING-delimiter findText result (endElement), NOT from a
+    // range derived from the equation span. findText(pattern, from) continues from `from`'s
+    // position; for single-`$` the opening and closing delimiter are the same character, so if we
+    // resume from anything anchored at the OPENING delimiter (the whole-equation range, the
+    // named-range span — both start at the opening `$`), findText re-finds this equation's own
+    // CLOSING `$` and pairs it forward with the next equation's opening `$`, rendering the prose
+    // between (and crossing paragraph breaks -> spurious "multi-paragraph" merges). endElement is a
+    // genuine findText result positioned at the closing delimiter, so the next search lands strictly
+    // after it on the following equation's opening delimiter. This mirrors the empty-equation path,
+    // which already resumes from endElement. (A previous fix re-read the named range's span here and
+    // passed the unit tests, but that span still starts at the opening `$`, so it mis-paired in
+    // production — confirmed via the Cloud Logging trace for a live user.)
+    var nextStartElement = endElement || namedRange.getRange().getRangeElements().slice(-1)[0];
     var clientRenderOptions = __assign(__assign({}, coloredRenderOptions), { size: size, rangeId: namedRange.getId(), equation: clientEquation, equationLinkEncoded: encodeURIComponent(clientEquation) });
     return {
         status: 2 /* DocsEquationRenderStatus.ClientRender */,

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -469,7 +469,12 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
     var placeHolderEnd = endElement.getEndOffsetInclusive(); //text between placeHolderStart and placeHolderEnd will be permanently deleted
     Common.debugLog(renderOptions.delim[2], " single escaped delimiters ", placeHolderEnd - placeHolderStart, " characters long");
     Common.reportDeltaTime(214);
-    if (placeHolderEnd - placeHolderStart == 2.0) {
+    // REASON: an empty equation contains only its opening and closing delimiters, so its
+    // inclusive span is exactly 2 * delimiter length. The legacy hard-coded `== 2` treated
+    // every one-character single-dollar equation (`$1$`, `$x$`) as empty, while failing to
+    // recognize actually-empty `$$$$`, `\[\]`, and `\(\)` pairs.
+    var isEmptyEquation = placeHolderEnd - placeHolderStart + 1 === 2 * renderOptions.delim[4];
+    if (isEmptyEquation) {
         // empty equation
         console.log("Empty equation! In index " + index + " and offset " + placeHolderStart);
         return {
@@ -562,6 +567,9 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
             }
         };
     }
+    // REASON: the MathJax path defers removal, so buildClientRenderResponse must return
+    // a post-NamedRange-mutation cursor. Do not pass either delimiter RangeElement through:
+    // adding the named range can make both pre-mutation search results stale.
     return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
 }
 function getEquation(rangeElement, delimiters) {
@@ -733,12 +741,20 @@ function buildClientRenderResponse(textElement, startElement, equationOriginal, 
         .build();
     // save this range for later
     var namedRange = doc.addNamedRange("ale-equation-range", range);
+    // REASON: addNamedRange mutates the Docs structure and can invalidate every
+    // RangeElement obtained before it, including startElement and the closing
+    // delimiter from findPos. Re-read the persisted range after the mutation and
+    // use that fresh whole-equation range as findText's continuation cursor. Its
+    // inclusive end is the closing delimiter, so the next result is the following
+    // equation's opening delimiter rather than the closing delimiter again.
+    var persistedRangeElements = namedRange.getRange().getRangeElements();
+    var nextStartElement = persistedRangeElements[persistedRangeElements.length - 1];
     var clientRenderOptions = __assign(__assign({}, coloredRenderOptions), { size: size, rangeId: namedRange.getId(), equation: clientEquation, equationLinkEncoded: encodeURIComponent(clientEquation) });
     return {
         status: 2 /* DocsEquationRenderStatus.ClientRender */,
         equationSize: size,
         clientRenderOptions: clientRenderOptions,
-        nextStartElement: startElement
+        nextStartElement: nextStartElement
     };
 }
 /**

--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -483,6 +483,26 @@ function findPos(index, renderOptions, prevFailedStartElemIfIsEmpty) {
             status: 3 /* DocsEquationRenderStatus.EmptyEquation */
         };
     }
+    // REASON: an equation whose content is only whitespace (most commonly a lone "\r" from an
+    // empty `$...$` that straddled a paragraph break and got auto-merged with a line break) is
+    // not a real equation. The old `== 2` empty check happened to skip it because its content was
+    // one character; the delimiter-length check above intentionally no longer does, so it now
+    // slips through to MathJax, which renders a 0x0 SVG and crashes convertToBlob with
+    // "OffscreenCanvas ... size is zero" (seen in prod as "MathJax failed to render 1 equation").
+    // Skip it exactly like an empty equation, resuming past the closing delimiter (endElement) so
+    // the scan can't re-pair the closing delimiter with the next equation. Only when start and end
+    // share a Text element (the common case); cross-element spans fall through to the logic below.
+    if (startElement.getElement() === endElement.getElement()) {
+        var between = startElement.getElement().asText().getText()
+            .substring(placeHolderStart + renderOptions.delim[4], placeHolderEnd - renderOptions.delim[4] + 1);
+        if (between.trim() === "") {
+            console.log("Whitespace-only equation skipped. In index " + index + " and offset " + placeHolderStart);
+            return {
+                nextStartElement: endElement,
+                status: 3 /* DocsEquationRenderStatus.EmptyEquation */
+            };
+        }
+    }
     // REASON: The legacy assumption was "start and end delimiters live in the same Text element."
     // That breaks in two real-world cases:
     //   1. Multi-paragraph equations: user pressed Enter (paragraph break) inside the equation

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -829,7 +829,7 @@ function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRender
  * @param {string}  delim[6]     The text delimiters and regex delimiters for start and end in that order, and offset from front and back.
  */
 
-function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.RangeElement,  renderOptions: AutoLatexCommon.RenderOptions, endElement?: GoogleAppsScript.Document.RangeElement): DocsEquationRenderResult {
+function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.RangeElement,  renderOptions: AutoLatexCommon.RenderOptions, endElement: GoogleAppsScript.Document.RangeElement): DocsEquationRenderResult {
   Common.reportDeltaTime(411);
   Common.reportDeltaTime(413);
   // GET VARIABLES
@@ -893,7 +893,7 @@ function buildClientRenderResponse(
   equationOriginal: string,
   coloredRenderOptions: AutoLatexCommon.RenderOptions & { r: number; g: number; b: number },
   size: number,
-  endElement?: GoogleAppsScript.Document.RangeElement
+  endElement: GoogleAppsScript.Document.RangeElement
 ): DocsEquationRenderResult {
   // REASON: reEncode turns each in-equation newline into an encoded four-backslash
   // marker ("%5C%5C%5C%5C%20"), which must collapse back to a "\\ " row break for the
@@ -923,7 +923,7 @@ function buildClientRenderResponse(
   // which already resumes from endElement. (A previous fix re-read the named range's span here and
   // passed the unit tests, but that span still starts at the opening `$`, so it mis-paired in
   // production — confirmed via the Cloud Logging trace for a live user.)
-  const nextStartElement = endElement || namedRange.getRange().getRangeElements().slice(-1)[0];
+  const nextStartElement = endElement;
   const clientRenderOptions: AutoLatexCommon.ClientRenderOptions = {
     ...coloredRenderOptions,
     size,

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -516,7 +516,16 @@ function tryAutoMergeMultiParagraphEquation(
     // \r (\u000D) is the in-text representation of a Shift+Enter line break in Docs.
     // See newlineCharacter comment near top of this file.
     startPara.editAsText().appendText("\r" + text);
-    nextPara.removeFromParent();
+    // REASON: Docs forbids deleting the final paragraph of a section — removeFromParent()
+    // throws "Can't remove the last paragraph in a document section" (seen in prod when an
+    // equation spans into the section's last paragraph). Its text is already merged into
+    // startPara, so when nextPara is that final paragraph, empty it in place instead of
+    // removing it; a trailing empty paragraph is harmless and the scan re-runs from scratch.
+    if (startParaIdx + 1 >= body.getNumChildren() - 1) {
+      nextPara.clear();
+    } else {
+      nextPara.removeFromParent();
+    }
   }
 
   return { success: true, reason: "Merged " + numToMerge + " paragraph(s) with line breaks" };

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -704,10 +704,11 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
     };
   }
 
-  // REASON: the MathJax path defers removal, so buildClientRenderResponse must return
-  // a post-NamedRange-mutation cursor. Do not pass either delimiter RangeElement through:
-  // adding the named range can make both pre-mutation search results stale.
-  return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
+  // REASON: pass endElement (the closing-delimiter findText result) so the deferred MathJax path
+  // can resume the scan strictly after this equation. Resuming from the equation span instead
+  // (which starts at the opening delimiter) makes findText re-find this equation's own closing
+  // `$` and pair it forward — see buildClientRenderResponse.
+  return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions, endElement);
 }
 
 
@@ -828,7 +829,7 @@ function clientRenderComplete(equations: { options: AutoLatexCommon.ClientRender
  * @param {string}  delim[6]     The text delimiters and regex delimiters for start and end in that order, and offset from front and back.
  */
 
-function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.RangeElement,  renderOptions: AutoLatexCommon.RenderOptions): DocsEquationRenderResult {
+function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.RangeElement,  renderOptions: AutoLatexCommon.RenderOptions, endElement?: GoogleAppsScript.Document.RangeElement): DocsEquationRenderResult {
   Common.reportDeltaTime(411);
   Common.reportDeltaTime(413);
   // GET VARIABLES
@@ -869,7 +870,7 @@ function findEquationAndPlaceImage(startElement: GoogleAppsScript.Document.Range
   // REASON: Explicit MathJax and Automatic both render on the client first.
   // Automatic falls back to server renderers from the sidebar only if MathJax fails.
   if (renderOptions.clientRender || renderOptions.autoFallbackToClient) {
-    return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size);
+    return buildClientRenderResponse(textElement, startElement, equationOriginal, coloredRenderOptions, size, endElement);
   }
 
   let { resp, renderer, worked, authorizationError } = renderEquationWithCompatibility(equationOriginal, coloredRenderOptions);
@@ -891,7 +892,8 @@ function buildClientRenderResponse(
   startElement: GoogleAppsScript.Document.RangeElement,
   equationOriginal: string,
   coloredRenderOptions: AutoLatexCommon.RenderOptions & { r: number; g: number; b: number },
-  size: number
+  size: number,
+  endElement?: GoogleAppsScript.Document.RangeElement
 ): DocsEquationRenderResult {
   // REASON: reEncode turns each in-equation newline into an encoded four-backslash
   // marker ("%5C%5C%5C%5C%20"), which must collapse back to a "\\ " row break for the
@@ -907,16 +909,21 @@ function buildClientRenderResponse(
   const range = doc.newRange()
     .addElement(textElement, startElement.getStartOffset(), startElement.getEndOffsetInclusive())
     .build();
-  // save this range for later
+  // save this range for later (used by clientRenderComplete to place the image)
   const namedRange = doc.addNamedRange("ale-equation-range", range);
-  // REASON: addNamedRange mutates the Docs structure and can invalidate every
-  // RangeElement obtained before it, including startElement and the closing
-  // delimiter from findPos. Re-read the persisted range after the mutation and
-  // use that fresh whole-equation range as findText's continuation cursor. Its
-  // inclusive end is the closing delimiter, so the next result is the following
-  // equation's opening delimiter rather than the closing delimiter again.
-  const persistedRangeElements = namedRange.getRange().getRangeElements();
-  const nextStartElement = persistedRangeElements[persistedRangeElements.length - 1];
+  // REASON: resume the scan from the CLOSING-delimiter findText result (endElement), NOT from a
+  // range derived from the equation span. findText(pattern, from) continues from `from`'s
+  // position; for single-`$` the opening and closing delimiter are the same character, so if we
+  // resume from anything anchored at the OPENING delimiter (the whole-equation range, the
+  // named-range span — both start at the opening `$`), findText re-finds this equation's own
+  // CLOSING `$` and pairs it forward with the next equation's opening `$`, rendering the prose
+  // between (and crossing paragraph breaks -> spurious "multi-paragraph" merges). endElement is a
+  // genuine findText result positioned at the closing delimiter, so the next search lands strictly
+  // after it on the following equation's opening delimiter. This mirrors the empty-equation path,
+  // which already resumes from endElement. (A previous fix re-read the named range's span here and
+  // passed the unit tests, but that span still starts at the opening `$`, so it mis-paired in
+  // production — confirmed via the Cloud Logging trace for a live user.)
+  const nextStartElement = endElement || namedRange.getRange().getRangeElements().slice(-1)[0];
   const clientRenderOptions: AutoLatexCommon.ClientRenderOptions = {
     ...coloredRenderOptions,
     size,

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -588,6 +588,27 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
     };
   }
 
+  // REASON: an equation whose content is only whitespace (most commonly a lone "\r" from an
+  // empty `$...$` that straddled a paragraph break and got auto-merged with a line break) is
+  // not a real equation. The old `== 2` empty check happened to skip it because its content was
+  // one character; the delimiter-length check above intentionally no longer does, so it now
+  // slips through to MathJax, which renders a 0x0 SVG and crashes convertToBlob with
+  // "OffscreenCanvas ... size is zero" (seen in prod as "MathJax failed to render 1 equation").
+  // Skip it exactly like an empty equation, resuming past the closing delimiter (endElement) so
+  // the scan can't re-pair the closing delimiter with the next equation. Only when start and end
+  // share a Text element (the common case); cross-element spans fall through to the logic below.
+  if (startElement.getElement() === endElement.getElement()) {
+    const between = startElement.getElement().asText().getText()
+      .substring(placeHolderStart + renderOptions.delim[4], placeHolderEnd - renderOptions.delim[4] + 1);
+    if (between.trim() === "") {
+      console.log("Whitespace-only equation skipped. In index " + index + " and offset " + placeHolderStart);
+      return {
+        nextStartElement: endElement,
+        status: DocsEquationRenderStatus.EmptyEquation
+      };
+    }
+  }
+
   // REASON: The legacy assumption was "start and end delimiters live in the same Text element."
   // That breaks in two real-world cases:
   //   1. Multi-paragraph equations: user pressed Enter (paragraph break) inside the equation

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -572,7 +572,12 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
   Common.debugLog(renderOptions.delim[2], " single escaped delimiters ", placeHolderEnd - placeHolderStart, " characters long");
 
   Common.reportDeltaTime(214);
-  if (placeHolderEnd - placeHolderStart == 2.0) {
+  // REASON: an empty equation contains only its opening and closing delimiters, so its
+  // inclusive span is exactly 2 * delimiter length. The legacy hard-coded `== 2` treated
+  // every one-character single-dollar equation (`$1$`, `$x$`) as empty, while failing to
+  // recognize actually-empty `$$$$`, `\[\]`, and `\(\)` pairs.
+  const isEmptyEquation = placeHolderEnd - placeHolderStart + 1 === 2 * renderOptions.delim[4];
+  if (isEmptyEquation) {
     // empty equation
     console.log("Empty equation! In index " + index + " and offset " + placeHolderStart);
 
@@ -669,6 +674,9 @@ function findPos(index: number, renderOptions: AutoLatexCommon.RenderOptions, pr
     };
   }
 
+  // REASON: the MathJax path defers removal, so buildClientRenderResponse must return
+  // a post-NamedRange-mutation cursor. Do not pass either delimiter RangeElement through:
+  // adding the named range can make both pre-mutation search results stale.
   return findEquationAndPlaceImage(range.getRangeElements()[0], renderOptions);
 }
 
@@ -871,6 +879,14 @@ function buildClientRenderResponse(
     .build();
   // save this range for later
   const namedRange = doc.addNamedRange("ale-equation-range", range);
+  // REASON: addNamedRange mutates the Docs structure and can invalidate every
+  // RangeElement obtained before it, including startElement and the closing
+  // delimiter from findPos. Re-read the persisted range after the mutation and
+  // use that fresh whole-equation range as findText's continuation cursor. Its
+  // inclusive end is the closing delimiter, so the next result is the following
+  // equation's opening delimiter rather than the closing delimiter again.
+  const persistedRangeElements = namedRange.getRange().getRangeElements();
+  const nextStartElement = persistedRangeElements[persistedRangeElements.length - 1];
   const clientRenderOptions: AutoLatexCommon.ClientRenderOptions = {
     ...coloredRenderOptions,
     size,
@@ -882,7 +898,7 @@ function buildClientRenderResponse(
     status: DocsEquationRenderStatus.ClientRender,
     equationSize: size,
     clientRenderOptions,
-    nextStartElement: startElement
+    nextStartElement
   };
 }
 

--- a/Docs/Sidebar.html
+++ b/Docs/Sidebar.html
@@ -69,7 +69,7 @@
             <!-- $("#instructions").val("<p>Replace all valid mathematical equations with high-quality LaTeX rendered images. Remember to wrap all latex in \[ ... \]. </p>"); -->
             <option value="\[">\[ ... \]</option>
             <option value="(">\( ... \)</option>
-            <option value="$">$ ... $</option>
+            <option value="$">$ ... $ (Beta)</option>
           </select>
           <br />
           <label id="select_size">Preferred Renderer:<br /></label>

--- a/Docs/Sidebar.html
+++ b/Docs/Sidebar.html
@@ -88,7 +88,7 @@
           <div id="button-container" class="button-container">
             <div id="render" class="button-row">
               <button id="insert-text" class="action button-in-row1">Render Equations</button>
-              <button id="edit-text" class="button-in-row1">De-render Equation</button>
+              <button id="edit-text" class="button-in-row1">De-render Selection</button>
             </div>
             <div id="derenderall" class="button-row">
               <button id="undo-all" class="create button-in-row2">De-render All Equations</button>
@@ -104,7 +104,7 @@
           <label id="tips">
             <br />
             <b>Tips:</b> <br />
-            • Click a rendered equation (or select several) and click "De-render Equation" to convert back to code. <br />
+            • Click a rendered equation (or select several) and click "De-render Selection" to convert back to code. <br />
             • Use shift+enter instead of enter for newlines in multi-line equations. Shift+enter auto-converts to \\.
             <!-- <br> • Click the sidebar and press ctrl+q to derender all equations. (beta) -->
             <br />

--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -398,7 +398,16 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
     }
 
     // we're not done yet - these equations need to be rendered on the client
-    const equationsToRender = clientEquations || [];
+    // REASON: an empty / whitespace-only equation (most often a lone "\r" produced when an
+    // empty `$...$` straddling a paragraph break gets auto-merged) typesets to a 0x0 SVG. The
+    // renderer throws on it, which otherwise counts as a failure and fires the alarming
+    // "MathJax failed to render N equation(s)" error. It is not a real equation, so drop it
+    // here: never rendered, never counted as a success or a failure. The server-side findPos
+    // guard catches the common single-paragraph case; this is the catch-all for whatever the
+    // merge path still lets through.
+    const equationsToRender = (clientEquations || []).filter(
+      c => typeof c.equation === "string" && c.equation.trim() !== ""
+    );
     mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async c => {
       try {
         return {

--- a/SidebarMathJaxShared.ts
+++ b/SidebarMathJaxShared.ts
@@ -96,6 +96,14 @@ async function renderEquationPngWithMathJax(
   const width = svg.clientWidth * 5;
   const height = svg.clientHeight * 5;
   svg.remove();
+  // REASON: a whitespace-only / empty equation (e.g. a lone "\r") typesets to a 0x0 SVG. A
+  // zero-size OffscreenCanvas then throws an opaque IndexSizeError in convertToBlob ("The size
+  // of OffscreenCanvas is zero"), which surfaced in prod as "MathJax failed to render 1
+  // equation(s)". Docs skips these upstream in findPos, but Slides/Sheets share this renderer,
+  // so fail fast here with a clear, self-explaining message instead of the canvas crash.
+  if (width <= 0 || height <= 0) {
+    throw new Error("Empty equation (zero-size render); nothing to rasterize.");
+  }
   svg.setAttribute("width", `${width}px`);
   svg.setAttribute("height", `${height}px`);
 

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -374,7 +374,10 @@ function findAllClientRenderEquationsInTextElement(
     const endOffset = Math.min(textRange.getLength(), equationOffsets.end + renderOptions.delim[4]);
     const equationRange = textRange.getRange(equationOffsets.start, endOffset);
     const equationOriginal = getEquation(equationRange, renderOptions.delim);
-    if (!equationOriginal) {
+    // REASON: skip empty AND whitespace-only equations (e.g. a lone line break). They typeset
+    // to a 0x0 SVG and would crash the shared client canvas renderer. Mirrors the Docs findPos
+    // guard so no surface sends a blank equation to MathJax.
+    if (!equationOriginal || equationOriginal.trim() === "") {
       searchOffset = equationOffsets.end + renderOptions.delim[4];
       continue;
     }
@@ -765,7 +768,10 @@ function findClientRenderEquationInTextElement(
     const endOffset = Math.min(textRange.getLength(), equationOffsets.end + renderOptions.delim[4]);
     const equationRange = textRange.getRange(equationOffsets.start, endOffset);
     const equationOriginal = getEquation(equationRange, renderOptions.delim);
-    if (!equationOriginal) {
+    // REASON: skip empty AND whitespace-only equations (e.g. a lone line break). They typeset
+    // to a 0x0 SVG and would crash the shared client canvas renderer. Mirrors the Docs findPos
+    // guard so no surface sends a blank equation to MathJax.
+    if (!equationOriginal || equationOriginal.trim() === "") {
       searchOffset = equationOffsets.end + renderOptions.delim[4];
       continue;
     }

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -1320,9 +1320,15 @@ function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEqu
         prevEnd = o.rangeEnd;
         successCount++;
       }
-      // NOTE: we intentionally KEEP the box (even if it's now only spaces) so derender can restore
-      // the equation into its space gap. A standalone equation box just becomes an invisible
-      // spaces box behind the floating image.
+
+      // REASON: a box that is now only whitespace held nothing but equations — drop it so the image
+      // floats on its own (the old behavior) instead of leaving an empty spaces box behind. Boxes
+      // that still contain prose keep their placeholder spaces so derender can restore inline.
+      if (!isTableCell(target.textElement) &&
+          target.textElement.getShapeType() === SlidesApp.ShapeType.TEXT_BOX &&
+          target.textRange.asRenderedString().trim().length === 0) {
+        target.textElement.remove();
+      }
     } catch (error) {
       console.error("MathJax Slides client render completion failed.", error);
     }

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -37,6 +37,11 @@ interface SlidesClientRenderOptions {
   tableColumn?: number;
   rangeStart: number;
   rangeEnd: number;
+  // Estimated position of the equation inside its text box, in points from the box's top-left.
+  // Computed at scan time (drift-free) so placement can put each image roughly where its source
+  // text was instead of stacking them all in the box corner. See estimateInBoxOffset.
+  posDx?: number;
+  posDy?: number;
 }
 
 interface SlidesClientRenderPayload {
@@ -391,6 +396,7 @@ function findAllClientRenderEquationsInTextElement(
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
     const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
+    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width);
 
     results.push({
       size,
@@ -407,7 +413,9 @@ function findAllClientRenderEquationsInTextElement(
       tableRow: isTableCell(textElement) ? textElement.getRowIndex() : undefined,
       tableColumn: isTableCell(textElement) ? textElement.getColumnIndex() : undefined,
       rangeStart: equationOffsets.start,
-      rangeEnd: endOffset
+      rangeEnd: endOffset,
+      posDx: eqOffset.dx,
+      posDy: eqOffset.dy
     });
 
     searchOffset = equationOffsets.end + renderOptions.delim[4];
@@ -785,6 +793,7 @@ function findClientRenderEquationInTextElement(
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
     const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
+    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width);
 
     return {
       size,
@@ -801,7 +810,9 @@ function findClientRenderEquationInTextElement(
       tableRow: isTableCell(textElement) ? textElement.getRowIndex() : undefined,
       tableColumn: isTableCell(textElement) ? textElement.getColumnIndex() : undefined,
       rangeStart: equationOffsets.start,
-      rangeEnd: endOffset
+      rangeEnd: endOffset,
+      posDx: eqOffset.dx,
+      posDy: eqOffset.dy
     };
   }
 
@@ -858,29 +869,87 @@ function getBounds(textElement: PageElement) {
   }
 }
 
-function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizontalAlignment: GoogleAppsScript.Slides.ParagraphAlignment, verticalAlignment: GoogleAppsScript.Slides.ContentAlignment, bounds: ReturnType<typeof getBounds>) {
+// REASON: Slides exposes no geometry for a substring inside a text box, so estimate where an
+// equation sits from the text that PRECEDES it, returning an (dx, dy) offset in points from the
+// box's top-left. Heuristic: average glyph advance ~= 0.5 * fontSize and line height ~= 1.2 *
+// fontSize, with a soft wrap when a visual line exceeds the box width. Graceful degradation
+// matching the requested fallback chain:
+//   - full inline: font size + box width known -> real column (dx) and wrapped line (dy)
+//   - line-aware:  no font metrics -> dx pinned to 0 (box edge), dy counts explicit breaks only
+//   - side-by-side/corner: empty prefix -> (0, 0); the placement step keeps alignment there and
+//     the slide-edge clamp guarantees nothing lands off-page (overlap is acceptable, off-slide is
+//     not).
+const GLYPH_ADVANCE_RATIO = 0.5; // avg glyph advance as a fraction of the font size (proportional)
+const LINE_HEIGHT_RATIO = 1.2;   // line height as a fraction of the font size
+function estimateInBoxOffset(textBefore: string, fontSizePt: number, boxWidthPt: number) {
+  const hasMetrics = typeof fontSizePt === "number" && fontSizePt > 0;
+  const fontPt = hasMetrics ? fontSizePt : 12;
+  const glyphW = Math.max(1, fontPt * GLYPH_ADVANCE_RATIO);
+  const lineH = Math.max(1, fontPt * LINE_HEIGHT_RATIO);
+  const charsPerLine = hasMetrics && boxWidthPt > 0 ? Math.max(1, Math.floor(boxWidthPt / glyphW)) : Infinity;
+
+  let line = 0;
+  let column = 0;
+  for (let i = 0; i < textBefore.length; i++) {
+    const ch = textBefore.charAt(i);
+    // \n \r \v are all in-text line breaks across Docs/Slides.
+    if (ch === "\n" || ch === "\r" || ch === "\v") {
+      line++;
+      column = 0;
+      continue;
+    }
+    column++;
+    if (column >= charsPerLine) {
+      line++;
+      column = 0;
+    }
+  }
+  return { dx: hasMetrics ? column * glyphW : 0, dy: line * lineH };
+}
+
+function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizontalAlignment: GoogleAppsScript.Slides.ParagraphAlignment, verticalAlignment: GoogleAppsScript.Slides.ContentAlignment, bounds: ReturnType<typeof getBounds>, posOffset?: { dx: number; dy: number }) {
   const width = eqnImage.getWidth() * scale;
   const height = eqnImage.getHeight() * scale;
-  
+
   eqnImage.setWidth(width);
   eqnImage.setHeight(height);
-  
-  // try to match the horizontal alignment of the text
-  if (horizontalAlignment === SlidesApp.ParagraphAlignment.END)
-    // subtracting the image width emulates "setRight"
-    eqnImage.setLeft(bounds.x + bounds.width - width); 
-  else if (horizontalAlignment === SlidesApp.ParagraphAlignment.CENTER)
-    eqnImage.setLeft(bounds.x + bounds.width / 2 - width / 2);
-  else
-    eqnImage.setLeft(bounds.x);
 
-  // match the vertical alignment
-  if (verticalAlignment === SlidesApp.ContentAlignment.TOP)
-    eqnImage.setTop(bounds.y);
-  else if (verticalAlignment === SlidesApp.ContentAlignment.BOTTOM)
-    eqnImage.setTop(bounds.y + bounds.height - height); // emulating "setBottom"
-  else
-    eqnImage.setTop(bounds.y + bounds.height / 2 - height / 2);
+  let left: number;
+  let top: number;
+  // Primary: the estimated inline position, but only when the equation actually has preceding
+  // content (dx>0 or dy>0). An equation at the very start of the box keeps the alignment-based
+  // placement below, which is correct for a single centered/right-aligned equation.
+  if (posOffset && (posOffset.dx > 0 || posOffset.dy > 0)) {
+    left = bounds.x + posOffset.dx;
+    top = bounds.y + posOffset.dy;
+  } else {
+    // horizontal: match the text alignment (box-edge / line-aware fallback)
+    if (horizontalAlignment === SlidesApp.ParagraphAlignment.END)
+      left = bounds.x + bounds.width - width; // subtracting the image width emulates "setRight"
+    else if (horizontalAlignment === SlidesApp.ParagraphAlignment.CENTER)
+      left = bounds.x + bounds.width / 2 - width / 2;
+    else
+      left = bounds.x;
+
+    // match the vertical alignment
+    if (verticalAlignment === SlidesApp.ContentAlignment.TOP)
+      top = bounds.y;
+    else if (verticalAlignment === SlidesApp.ContentAlignment.BOTTOM)
+      top = bounds.y + bounds.height - height; // emulating "setBottom"
+    else
+      top = bounds.y + bounds.height / 2 - height / 2;
+  }
+
+  // REASON: never let the image run off the right/bottom edge of the slide. Clamp to the page;
+  // overlapping another element is acceptable, disappearing off-slide is not (user spec).
+  const presentation = SlidesApp.getActivePresentation();
+  const slideWidth = presentation.getPageWidth();
+  const slideHeight = presentation.getPageHeight();
+  left = Math.max(0, Math.min(left, slideWidth - width));
+  top = Math.max(0, Math.min(top, slideHeight - height));
+
+  eqnImage.setLeft(left);
+  eqnImage.setTop(top);
 }
 
 /**
@@ -1065,7 +1134,13 @@ function placeClientRenderedImage(
   text.clear();
 
   const image = slide.insertImage(renderedEquation);
-  resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds);
+  // Place the image at its estimated inline position within the box (computed at scan time from
+  // the preceding text); resize() falls back to alignment-based placement when there is no offset
+  // and always clamps to the slide edges.
+  resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds, {
+    dx: renderOptions.posDx || 0,
+    dy: renderOptions.posDy || 0
+  });
 
   if (
     !isTableCell(textElement) &&

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -16,7 +16,15 @@ interface DerenderData {
   origURL: string,
   size: number,
   width: number,
-  height: number
+  height: number,
+  // Space-fill bookkeeping: when the equation's source text was replaced by `spaceCount` spaces in
+  // its original box (so surrounding prose held its position), derender restores the equation into
+  // that gap instead of spawning a new text box. Absent on images placed the old (clear) way.
+  slideId?: string,
+  pageElementId?: string,
+  tableRow?: number,
+  tableColumn?: number,
+  spaceCount?: number
 }
 
 interface SlidesClientRenderOptions {
@@ -44,6 +52,11 @@ interface SlidesClientRenderOptions {
   posDx?: number;
   posDy?: number;
   posLineHeight?: number;
+  // Inputs for exact client-side measurement (Canvas measureText) — the sidebar recomputes
+  // posDx/posDy from these using the real font, overriding the server's Arial estimate above.
+  precedingText?: string;
+  fontFamily?: string;
+  boxUsableWidth?: number;
 }
 
 interface SlidesClientRenderPayload {
@@ -1170,75 +1183,146 @@ function resolveClientRenderTarget(options: SlidesClientRenderOptions) {
   };
 }
 
-function placeClientRenderedImage(
-  slide: GoogleAppsScript.Slides.Slide,
-  textElement: PageElement,
-  text: GoogleAppsScript.Slides.TextRange,
-  renderOptions: SlidesClientRenderOptions,
-  renderedEquation: GoogleAppsScript.Base.Blob
+// Advance a { x, line } cursor over plain text using per-glyph widths (points), wrapping when the
+// running line width exceeds usableWidthPt. Mutates the cursor.
+function advanceCursorOverText(cursor: { x: number; line: number }, text: string, fontPt: number, usableWidthPt: number) {
+  const maxWidth = usableWidthPt > 0 ? usableWidthPt : Infinity;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charAt(i);
+    if (ch === "\n" || ch === "\r" || ch === "\v") {
+      cursor.line++;
+      cursor.x = 0;
+      continue;
+    }
+    const w = glyphWidthEm(ch) * fontPt;
+    if (cursor.x + w > maxWidth && cursor.x > 0) {
+      cursor.line++;
+      cursor.x = 0;
+    }
+    cursor.x += w;
+  }
+}
+
+type SlidesRenderTarget = NonNullable<ReturnType<typeof resolveClientRenderTarget>>;
+
+// Place one rendered image at an explicit box-relative (dx, dy) position, then replace the
+// equation's live source range with spaces whose combined width matches the image, so the
+// surrounding prose keeps its place and the image slots into the gap. Records the box + space
+// count in the image title so derender can restore the equation into that exact gap.
+function placeImageAndFillSpaces(
+  target: SlidesRenderTarget,
+  options: SlidesClientRenderOptions,
+  bounds: ReturnType<typeof getBounds>,
+  equationRange: GoogleAppsScript.Slides.TextRange,
+  liveStart: number,
+  renderedEquation: GoogleAppsScript.Base.Blob,
+  pos: { dx: number; dy: number; lineHeight: number }
 ) {
-  const equationRange = text.getRange(1, text.getLength());
   const textHorizontalAlignment = equationRange
     .getParagraphs()[0]
     .getRange()
     .getParagraphStyle()
     .getParagraphAlignment();
-  const textVerticalAlignment = textElement.getContentAlignment();
-  const bounds = getBounds(textElement);
+  const textVerticalAlignment = target.textElement.getContentAlignment();
   const mathJaxRenderer = Common.getRenderer(Common.rendererIds.MATHJAX);
+
+  const image = target.slide.insertImage(renderedEquation);
+  resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds, pos);
+  const imageWidth = image.getWidth();
+
+  // Replace the equation source with spaces sized to the rendered image (Arial space = 0.278 em).
+  const fontPt = options.size > 0 ? options.size : 12;
+  const spaceWidthPt = glyphWidthEm(" ") * fontPt;
+  const spaceCount = Math.max(1, Math.round(imageWidth / spaceWidthPt));
+  equationRange.clear();
+  target.textRange.insertText(liveStart, " ".repeat(spaceCount));
+
   const derenderData: DerenderData = {
-    red: renderOptions.r,
-    green: renderOptions.g,
-    blue: renderOptions.b,
-    origURL: mathJaxRenderer[2] + renderOptions.equationLinkEncoded + "#" + renderOptions.delim[6],
-    size: renderOptions.size,
+    red: options.r,
+    green: options.g,
+    blue: options.b,
+    origURL: mathJaxRenderer[2] + options.equationLinkEncoded + "#" + options.delim[6],
+    size: options.size,
     width: bounds.width,
-    height: bounds.height
+    height: bounds.height,
+    slideId: options.slideId,
+    pageElementId: options.pageElementId,
+    tableRow: options.tableRow,
+    tableColumn: options.tableColumn,
+    spaceCount
   };
-
-  text.clear();
-
-  const image = slide.insertImage(renderedEquation);
-  // Place the image at its estimated inline position within the box (computed at scan time from
-  // the preceding text); resize() falls back to alignment-based placement when there is no offset
-  // and always clamps to the slide edges.
-  resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds, {
-    dx: renderOptions.posDx || 0,
-    dy: renderOptions.posDy || 0,
-    lineHeight: renderOptions.posLineHeight || 0
-  });
-
-  if (
-    !isTableCell(textElement) &&
-    textElement.getShapeType() === SlidesApp.ShapeType.TEXT_BOX &&
-    textElement.getText().asRenderedString().length <= 1
-  ) {
-    textElement.remove();
-  }
-
   image.setTitle(JSON.stringify(derenderData));
+
+  return { imageWidth, spaceCount };
 }
 
 function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEquationRenderResult {
   let successCount = 0;
 
+  // REASON: lay out each box's equations left-to-right with a running cursor that advances by each
+  // equation's RENDERED image width (not its wider source-text width). That is what stops a second
+  // equation on the same line from drifting right, and it's why we group by box first.
+  const boxes = new Map<string, SlidesClientRenderPayload[]>();
   for (const equation of equations) {
+    const o = equation.options;
+    const key = [o.slideId, o.pageElementId, o.tableRow ?? "", o.tableColumn ?? ""].join("|");
+    const list = boxes.get(key);
+    if (list) list.push(equation);
+    else boxes.set(key, [equation]);
+  }
+
+  for (const group of Array.from(boxes.values())) {
     try {
-      const target = resolveClientRenderTarget(equation.options);
+      const target = resolveClientRenderTarget(group[0].options);
       if (!target) {
-        console.warn("MathJax Slides target disappeared before completion:", equation.options.pageElementId);
+        console.warn("MathJax Slides target disappeared before completion:", group[0].options.pageElementId);
         continue;
       }
+      const originalText = target.textRange.asRenderedString();
+      const bounds = getBounds(target.textElement);
+      const usableWidth = bounds.width - 2 * BOX_LEFT_INSET_PT;
 
-      const safeEnd = Math.min(target.textRange.getLength(), equation.options.rangeEnd);
-      if (equation.options.rangeStart >= safeEnd) {
-        continue;
+      group.sort((a, b) => a.options.rangeStart - b.options.rangeStart);
+
+      const cursor = { x: 0, line: 0 };
+      let prevEnd = 0;   // end offset (in ORIGINAL text) of the previous equation
+      let liveDelta = 0; // running length change to the box text as equations become spaces
+
+      for (const equation of group) {
+        const o = equation.options;
+        const fontPt = o.size > 0 ? o.size : 12;
+        const lineHeight = fontPt * LINE_HEIGHT_RATIO;
+
+        // walk the plain text between the previous equation and this one
+        advanceCursorOverText(cursor, originalText.substring(prevEnd, o.rangeStart), fontPt, usableWidth);
+        const posDx = cursor.x;
+        const posDy = cursor.line * lineHeight;
+
+        // the equation's live range shifts as earlier equations in this box become spaces
+        const liveStart = o.rangeStart + liveDelta;
+        const liveEnd = Math.min(target.textRange.getLength(), o.rangeEnd + liveDelta);
+        if (liveStart >= liveEnd) {
+          prevEnd = o.rangeEnd;
+          continue;
+        }
+
+        const equationRange = target.textRange.getRange(liveStart, liveEnd);
+        const blob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
+        const placed = placeImageAndFillSpaces(target, o, bounds, equationRange, liveStart, blob, { dx: posDx, dy: posDy, lineHeight });
+
+        cursor.x += placed.imageWidth;                                  // equation occupies its image width
+        liveDelta += placed.spaceCount - (o.rangeEnd - o.rangeStart);   // net length change from the space-fill
+        prevEnd = o.rangeEnd;
+        successCount++;
       }
 
-      const equationRange = target.textRange.getRange(equation.options.rangeStart, safeEnd);
-      const equationBlob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
-      placeClientRenderedImage(target.slide, target.textElement, equationRange, equation.options, equationBlob);
-      successCount++;
+      // REASON: a box that is now only whitespace was a standalone equation box; drop it so the
+      // image floats on its own (the old behavior), instead of leaving an empty box behind.
+      if (!isTableCell(target.textElement) &&
+          target.textElement.getShapeType() === SlidesApp.ShapeType.TEXT_BOX &&
+          target.textRange.asRenderedString().trim().length === 0) {
+        target.textElement.remove();
+      }
     } catch (error) {
       console.error("MathJax Slides client render completion failed.", error);
     }
@@ -1366,8 +1450,6 @@ function derenderImage(image: GoogleAppsScript.Slides.Image, defaultDelim: AutoL
   // these _should_ be numbers already, but I'm leaving this here in case it's needed for backwards compatibility
   const colors = [red, green, blue].map((x: string | number) => Number(x)) as [number, number, number];
 
-  image.remove();
-
   Common.debugLog("image description is: " + origURL);
 
   if (!origURL) return Common.DerenderResult.NullUrl;
@@ -1391,22 +1473,86 @@ function derenderImage(image: GoogleAppsScript.Slides.Image, defaultDelim: AutoL
     return Common.DerenderResult.EmptyEquation;
   }
 
-  // insert textbox
+  const equationText = delim[0] + origEq + delim[1];
+
+  // Preferred path: images placed with the space-fill recorded their original box + the number of
+  // placeholder spaces. Restore the equation into that exact gap so the surrounding prose is
+  // untouched, then remove the image.
+  if (derenderData.spaceCount && derenderData.pageElementId) {
+    if (restoreEquationIntoSpaceGap(slide, derenderData, equationText, colors, size)) {
+      image.remove();
+      return Common.DerenderResult.Success;
+    }
+    // gap not found (box deleted or spaces edited) — fall through to the legacy new-box path
+  }
+
+  image.remove();
+
+  // Legacy / fallback path: drop a fresh text box at the image's former position.
   const shape = slide.insertShape(SlidesApp.ShapeType.TEXT_BOX, positionX, positionY, width, height);
   const textRange = shape.getText();
 
   const textStyle = textRange
-    .insertText(0, delim[0] + origEq + delim[1])
+    .insertText(0, equationText)
     .getTextStyle()
     .setForegroundColor(...colors);
 
   if (size) {
     textStyle.setFontSize(size);
   }
-  
+
   Common.debugLog("textRange: " + textRange + "type: " + typeof textRange);
-  
+
   return Common.DerenderResult.Success;
+}
+
+// Find a run of EXACTLY `count` consecutive spaces in boxText; returns its start offset or -1.
+function findSpaceGap(boxText: string, count: number): number {
+  let i = 0;
+  while (i < boxText.length) {
+    if (boxText.charAt(i) === " ") {
+      let j = i;
+      while (j < boxText.length && boxText.charAt(j) === " ") j++;
+      if (j - i === count) return i;
+      i = j;
+    } else {
+      i++;
+    }
+  }
+  return -1;
+}
+
+// Resolve the TextRange of the box (shape or table cell) recorded in a space-fill DerenderData.
+function resolveDerenderBoxTextRange(slide: GoogleAppsScript.Slides.Page | GoogleAppsScript.Slides.Slide, derenderData: DerenderData) {
+  if (!derenderData.pageElementId) return null;
+  const pageElement = findPageElementById(slide.getPageElements(), derenderData.pageElementId);
+  if (!pageElement) return null;
+  if (derenderData.tableRow != null && derenderData.tableColumn != null) {
+    if (pageElement.getPageElementType() !== SlidesApp.PageElementType.TABLE) return null;
+    return pageElement.asTable().getCell(derenderData.tableRow, derenderData.tableColumn).getText();
+  }
+  if (pageElement.getPageElementType() !== SlidesApp.PageElementType.SHAPE) return null;
+  return pageElement.asShape().getText();
+}
+
+// Replace the placeholder space gap in the original box with the equation text. Returns false if
+// the box or a matching gap can't be found, so the caller can fall back to a new text box.
+function restoreEquationIntoSpaceGap(
+  slide: GoogleAppsScript.Slides.Page | GoogleAppsScript.Slides.Slide,
+  derenderData: DerenderData,
+  equationText: string,
+  colors: [number, number, number],
+  size: number
+): boolean {
+  const boxTextRange = resolveDerenderBoxTextRange(slide, derenderData);
+  if (!boxTextRange) return false;
+  const gapStart = findSpaceGap(boxTextRange.asRenderedString(), derenderData.spaceCount as number);
+  if (gapStart < 0) return false;
+
+  boxTextRange.getRange(gapStart, gapStart + (derenderData.spaceCount as number)).clear();
+  const textStyle = boxTextRange.insertText(gapStart, equationText).getTextStyle().setForegroundColor(...colors);
+  if (size) textStyle.setFontSize(size);
+  return true;
 }
 
 /**

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -39,9 +39,11 @@ interface SlidesClientRenderOptions {
   rangeEnd: number;
   // Estimated position of the equation inside its text box, in points from the box's top-left.
   // Computed at scan time (drift-free) so placement can put each image roughly where its source
-  // text was instead of stacking them all in the box corner. See estimateInBoxOffset.
+  // text was instead of stacking them all in the box corner. posLineHeight lets placement anchor
+  // the image's bottom to the text line's bottom. See estimateInBoxOffset.
   posDx?: number;
   posDy?: number;
+  posLineHeight?: number;
 }
 
 interface SlidesClientRenderPayload {
@@ -419,7 +421,8 @@ function findAllClientRenderEquationsInTextElement(
       rangeStart: equationOffsets.start,
       rangeEnd: endOffset,
       posDx: eqOffset.dx,
-      posDy: eqOffset.dy
+      posDy: eqOffset.dy,
+      posLineHeight: eqOffset.lineHeight
     });
 
     searchOffset = equationOffsets.end + renderOptions.delim[4];
@@ -820,7 +823,8 @@ function findClientRenderEquationInTextElement(
       rangeStart: equationOffsets.start,
       rangeEnd: endOffset,
       posDx: eqOffset.dx,
-      posDy: eqOffset.dy
+      posDy: eqOffset.dy,
+      posLineHeight: eqOffset.lineHeight
     };
   }
 
@@ -890,7 +894,9 @@ function getBounds(textElement: PageElement) {
 const LINE_HEIGHT_RATIO = 1.2; // line height as a fraction of the font size
 // Slides' default text-box insets (padding) — text starts this far from the box's top-left, so
 // the estimated position must too. Not readable via Apps Script, so use the product defaults.
-const BOX_LEFT_INSET_PT = 7.2; // 0.1"
+// Nudged slightly below the geometric 0.1" left inset to absorb the rendered image's own left
+// bearing (a small whitespace margin baked into the PNG), which read as "a tad too far right".
+const BOX_LEFT_INSET_PT = 5.4;
 const BOX_TOP_INSET_PT = 3.6;  // 0.05"
 // REASON: per-glyph advance widths in em (fraction of font size), Helvetica/Arial metrics — the
 // default Slides font. A flat 0.5 overestimated narrow glyphs (i, l, spaces, punctuation) and
@@ -949,10 +955,12 @@ function estimateInBoxOffset(textBefore: string, fontSizePt: number, usableWidth
     }
     x += w;
   }
-  return { dx: hasMetrics ? x : 0, dy: line * lineH };
+  // dy is the TOP of the equation's line; lineHeight lets placement anchor the image's BOTTOM to
+  // the line's bottom (equations should sit on the text baseline, not float at the line top).
+  return { dx: hasMetrics ? x : 0, dy: line * lineH, lineHeight: lineH };
 }
 
-function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizontalAlignment: GoogleAppsScript.Slides.ParagraphAlignment, verticalAlignment: GoogleAppsScript.Slides.ContentAlignment, bounds: ReturnType<typeof getBounds>, posOffset?: { dx: number; dy: number }) {
+function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizontalAlignment: GoogleAppsScript.Slides.ParagraphAlignment, verticalAlignment: GoogleAppsScript.Slides.ContentAlignment, bounds: ReturnType<typeof getBounds>, posOffset?: { dx: number; dy: number; lineHeight: number }) {
   const width = eqnImage.getWidth() * scale;
   const height = eqnImage.getHeight() * scale;
 
@@ -968,7 +976,10 @@ function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizont
     // add the box insets so the image lines up with the text's actual content origin, not the
     // box's outer corner (this is what pulled images up-and-right of their source text).
     left = bounds.x + BOX_LEFT_INSET_PT + posOffset.dx;
-    top = bounds.y + BOX_TOP_INSET_PT + posOffset.dy;
+    // anchor the image's BOTTOM to the bottom of the equation's text line (posDy is the line top,
+    // so posDy + lineHeight is the line bottom). Anchoring the top made tall equation images float
+    // above the text; equations should sit on the baseline.
+    top = bounds.y + BOX_TOP_INSET_PT + posOffset.dy + posOffset.lineHeight - height;
   } else {
     // horizontal: match the text alignment (box-edge / line-aware fallback)
     if (horizontalAlignment === SlidesApp.ParagraphAlignment.END)
@@ -1193,7 +1204,8 @@ function placeClientRenderedImage(
   // and always clamps to the slide edges.
   resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds, {
     dx: renderOptions.posDx || 0,
-    dy: renderOptions.posDy || 0
+    dy: renderOptions.posDy || 0,
+    lineHeight: renderOptions.posLineHeight || 0
   });
 
   if (

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -53,11 +53,11 @@ interface SlidesClientRenderOptions {
   posDx?: number;
   posDy?: number;
   posLineHeight?: number;
-  // Inputs for exact client-side measurement (Canvas measureText) — the sidebar recomputes
-  // posDx/posDy from these using the real font, overriding the server's Arial estimate above.
-  precedingText?: string;
+  // The equation's font family (server) so the sidebar can load it and measure it.
   fontFamily?: string;
-  boxUsableWidth?: number;
+  // Per-glyph advance widths in em, measured on the CLIENT with Canvas measureText for fontFamily
+  // (exact for any font). The server cursor uses these instead of the hardcoded Arial table.
+  glyphWidths?: { [ch: string]: number };
 }
 
 interface SlidesClientRenderPayload {
@@ -436,7 +436,8 @@ function findAllClientRenderEquationsInTextElement(
       rangeEnd: endOffset,
       posDx: eqOffset.dx,
       posDy: eqOffset.dy,
-      posLineHeight: eqOffset.lineHeight
+      posLineHeight: eqOffset.lineHeight,
+      fontFamily: getFontFamilySafe(equationRange)
     });
 
     searchOffset = equationOffsets.end + renderOptions.delim[4];
@@ -838,7 +839,8 @@ function findClientRenderEquationInTextElement(
       rangeEnd: endOffset,
       posDx: eqOffset.dx,
       posDy: eqOffset.dy,
-      posLineHeight: eqOffset.lineHeight
+      posLineHeight: eqOffset.lineHeight,
+      fontFamily: getFontFamilySafe(equationRange)
     };
   }
 
@@ -928,7 +930,9 @@ const GLYPH_WIDTHS_EM: { [ch: string]: number } = {
   "q": 0.556, "r": 0.333, "s": 0.5, "t": 0.278, "u": 0.556, "v": 0.5, "w": 0.722, "x": 0.5,
   "y": 0.5, "z": 0.5, "{": 0.334, "|": 0.26, "}": 0.334, "~": 0.584
 };
-function glyphWidthEm(ch: string) {
+function glyphWidthEm(ch: string, table?: { [ch: string]: number }) {
+  // Prefer the client-measured table for the actual font; fall back to the Arial estimate.
+  if (table && ch in table) return table[ch];
   if (ch in GLYPH_WIDTHS_EM) return GLYPH_WIDTHS_EM[ch];
   if (ch >= "0" && ch <= "9") return 0.556;
   return 0.5;
@@ -937,6 +941,15 @@ function glyphWidthEm(ch: string) {
 // A white / near-white background is treated as "no background" (transparent equation image).
 function isNearWhite(rgb: number[]) {
   return rgb[0] >= 250 && rgb[1] >= 250 && rgb[2] >= 250;
+}
+
+// The font family of a text range, for the sidebar to load + measure. Null for mixed runs.
+function getFontFamilySafe(range: GoogleAppsScript.Slides.TextRange): string | undefined {
+  try {
+    return range.getTextStyle().getFontFamily() || undefined;
+  } catch (e) {
+    return undefined;
+  }
 }
 
 // REASON: Slides exposes no geometry for a substring inside a text box, so estimate where an
@@ -1186,7 +1199,7 @@ function resolveClientRenderTarget(options: SlidesClientRenderOptions) {
 
 // Advance a { x, line } cursor over plain text using per-glyph widths (points), wrapping when the
 // running line width exceeds usableWidthPt. Mutates the cursor.
-function advanceCursorOverText(cursor: { x: number; line: number }, text: string, fontPt: number, usableWidthPt: number) {
+function advanceCursorOverText(cursor: { x: number; line: number }, text: string, fontPt: number, usableWidthPt: number, table?: { [ch: string]: number }) {
   const maxWidth = usableWidthPt > 0 ? usableWidthPt : Infinity;
   for (let i = 0; i < text.length; i++) {
     const ch = text.charAt(i);
@@ -1195,7 +1208,7 @@ function advanceCursorOverText(cursor: { x: number; line: number }, text: string
       cursor.x = 0;
       continue;
     }
-    const w = glyphWidthEm(ch) * fontPt;
+    const w = glyphWidthEm(ch, table) * fontPt;
     if (cursor.x + w > maxWidth && cursor.x > 0) {
       cursor.line++;
       cursor.x = 0;
@@ -1231,9 +1244,9 @@ function placeImageAndFillSpaces(
   resize(image, 1.26 / 5, textHorizontalAlignment, textVerticalAlignment, bounds, pos);
   const imageWidth = image.getWidth();
 
-  // Replace the equation source with spaces sized to the rendered image (Arial space = 0.278 em).
+  // Replace the equation source with spaces sized to the rendered image (real font's space width).
   const fontPt = options.size > 0 ? options.size : 12;
-  const spaceWidthPt = glyphWidthEm(" ") * fontPt;
+  const spaceWidthPt = glyphWidthEm(" ", options.glyphWidths) * fontPt;
   const spaceCount = Math.max(1, Math.round(imageWidth / spaceWidthPt));
   equationRange.clear();
   target.textRange.insertText(liveStart, " ".repeat(spaceCount));
@@ -1295,8 +1308,8 @@ function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEqu
         const fontPt = o.size > 0 ? o.size : 12;
         const lineHeight = fontPt * LINE_HEIGHT_RATIO;
 
-        // walk the plain text between the previous equation and this one
-        advanceCursorOverText(cursor, originalText.substring(prevEnd, o.rangeStart), fontPt, usableWidth);
+        // walk the plain text between the previous equation and this one (real font widths)
+        advanceCursorOverText(cursor, originalText.substring(prevEnd, o.rangeStart), fontPt, usableWidth, o.glyphWidths);
         const posDx = cursor.x;
         const posDy = cursor.line * lineHeight;
 
@@ -1315,7 +1328,7 @@ function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEqu
         // REASON: advance by the GAP width (the spaces the box actually lays out), not the image
         // width. If these differ, the next equation's image lands off its own gap (first-right /
         // second-left). Keeping the cursor in lockstep with the box's spaces keeps them aligned.
-        cursor.x += placed.spaceCount * (glyphWidthEm(" ") * fontPt);
+        cursor.x += placed.spaceCount * (glyphWidthEm(" ", o.glyphWidths) * fontPt);
         liveDelta += placed.spaceCount - (o.rangeEnd - o.rangeStart); // net length change from the space-fill
         prevEnd = o.rangeEnd;
         successCount++;

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -390,13 +390,17 @@ function findAllClientRenderEquationsInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
+    const bgColorRaw = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
+    // REASON: a white / near-white background should render as transparent, not a baked white box.
+    // Otherwise every equation on a normal white slide gets an opaque rectangle. Only a genuinely
+    // colored highlight/fill is baked in.
+    const bgColor = bgColorRaw && !isNearWhite(bgColorRaw) ? bgColorRaw : null;
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
     const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
-    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width);
+    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width - 2 * BOX_LEFT_INSET_PT);
 
     results.push({
       size,
@@ -787,13 +791,17 @@ function findClientRenderEquationInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColor = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
+    const bgColorRaw = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
+    // REASON: a white / near-white background should render as transparent, not a baked white box.
+    // Otherwise every equation on a normal white slide gets an opaque rectangle. Only a genuinely
+    // colored highlight/fill is baked in.
+    const bgColor = bgColorRaw && !isNearWhite(bgColorRaw) ? bgColorRaw : null;
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
     // \hline" after a derender round-trip) and align/matrix row breaks.
     const clientEquation = Common.getClientEquation(equationOriginal, IntegratedApp);
-    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width);
+    const eqOffset = estimateInBoxOffset(renderedText.substring(0, equationOffsets.start), size, getBounds(textElement).width - 2 * BOX_LEFT_INSET_PT);
 
     return {
       size,
@@ -879,32 +887,69 @@ function getBounds(textElement: PageElement) {
 //   - side-by-side/corner: empty prefix -> (0, 0); the placement step keeps alignment there and
 //     the slide-edge clamp guarantees nothing lands off-page (overlap is acceptable, off-slide is
 //     not).
-const GLYPH_ADVANCE_RATIO = 0.5; // avg glyph advance as a fraction of the font size (proportional)
-const LINE_HEIGHT_RATIO = 1.2;   // line height as a fraction of the font size
-function estimateInBoxOffset(textBefore: string, fontSizePt: number, boxWidthPt: number) {
+const LINE_HEIGHT_RATIO = 1.2; // line height as a fraction of the font size
+// Slides' default text-box insets (padding) — text starts this far from the box's top-left, so
+// the estimated position must too. Not readable via Apps Script, so use the product defaults.
+const BOX_LEFT_INSET_PT = 7.2; // 0.1"
+const BOX_TOP_INSET_PT = 3.6;  // 0.05"
+// REASON: per-glyph advance widths in em (fraction of font size), Helvetica/Arial metrics — the
+// default Slides font. A flat 0.5 overestimated narrow glyphs (i, l, spaces, punctuation) and
+// pushed images right of their text. Digits are 0.556; anything unlisted falls back to 0.5.
+const GLYPH_WIDTHS_EM: { [ch: string]: number } = {
+  " ": 0.278, "!": 0.278, "\"": 0.355, "#": 0.556, "$": 0.556, "%": 0.889, "&": 0.667, "'": 0.191,
+  "(": 0.333, ")": 0.333, "*": 0.389, "+": 0.584, ",": 0.278, "-": 0.333, ".": 0.278, "/": 0.278,
+  ":": 0.278, ";": 0.278, "<": 0.584, "=": 0.584, ">": 0.584, "?": 0.556, "@": 1.015,
+  "A": 0.667, "B": 0.667, "C": 0.722, "D": 0.722, "E": 0.667, "F": 0.611, "G": 0.778, "H": 0.722,
+  "I": 0.278, "J": 0.5, "K": 0.667, "L": 0.556, "M": 0.833, "N": 0.722, "O": 0.778, "P": 0.667,
+  "Q": 0.778, "R": 0.722, "S": 0.667, "T": 0.611, "U": 0.722, "V": 0.667, "W": 0.944, "X": 0.667,
+  "Y": 0.667, "Z": 0.611, "[": 0.278, "\\": 0.278, "]": 0.278, "^": 0.469, "_": 0.556, "`": 0.333,
+  "a": 0.556, "b": 0.556, "c": 0.5, "d": 0.556, "e": 0.556, "f": 0.278, "g": 0.556, "h": 0.556,
+  "i": 0.222, "j": 0.222, "k": 0.5, "l": 0.222, "m": 0.833, "n": 0.556, "o": 0.556, "p": 0.556,
+  "q": 0.556, "r": 0.333, "s": 0.5, "t": 0.278, "u": 0.556, "v": 0.5, "w": 0.722, "x": 0.5,
+  "y": 0.5, "z": 0.5, "{": 0.334, "|": 0.26, "}": 0.334, "~": 0.584
+};
+function glyphWidthEm(ch: string) {
+  if (ch in GLYPH_WIDTHS_EM) return GLYPH_WIDTHS_EM[ch];
+  if (ch >= "0" && ch <= "9") return 0.556;
+  return 0.5;
+}
+
+// A white / near-white background is treated as "no background" (transparent equation image).
+function isNearWhite(rgb: number[]) {
+  return rgb[0] >= 250 && rgb[1] >= 250 && rgb[2] >= 250;
+}
+
+// REASON: Slides exposes no geometry for a substring inside a text box, so estimate where an
+// equation sits from the text that PRECEDES it, returning an (dx, dy) offset in points from the
+// box's top-left content origin. Sum real per-glyph advances for the horizontal position and
+// soft-wrap when the running width exceeds the box's usable width. Graceful degradation:
+//   - full inline: font size known -> real glyph-width column (dx) and wrapped line (dy)
+//   - line-aware:  no font size -> dx = 0 (box edge), dy counts explicit breaks only
+//   - box start:   empty prefix -> (0, 0); placement keeps alignment there.
+function estimateInBoxOffset(textBefore: string, fontSizePt: number, usableWidthPt: number) {
   const hasMetrics = typeof fontSizePt === "number" && fontSizePt > 0;
   const fontPt = hasMetrics ? fontSizePt : 12;
-  const glyphW = Math.max(1, fontPt * GLYPH_ADVANCE_RATIO);
   const lineH = Math.max(1, fontPt * LINE_HEIGHT_RATIO);
-  const charsPerLine = hasMetrics && boxWidthPt > 0 ? Math.max(1, Math.floor(boxWidthPt / glyphW)) : Infinity;
+  const maxLineWidth = hasMetrics && usableWidthPt > 0 ? usableWidthPt : Infinity;
 
   let line = 0;
-  let column = 0;
+  let x = 0; // width accumulated on the current line, in points
   for (let i = 0; i < textBefore.length; i++) {
     const ch = textBefore.charAt(i);
     // \n \r \v are all in-text line breaks across Docs/Slides.
     if (ch === "\n" || ch === "\r" || ch === "\v") {
       line++;
-      column = 0;
+      x = 0;
       continue;
     }
-    column++;
-    if (column >= charsPerLine) {
+    const w = glyphWidthEm(ch) * fontPt;
+    if (x + w > maxLineWidth) { // soft wrap
       line++;
-      column = 0;
+      x = 0;
     }
+    x += w;
   }
-  return { dx: hasMetrics ? column * glyphW : 0, dy: line * lineH };
+  return { dx: hasMetrics ? x : 0, dy: line * lineH };
 }
 
 function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizontalAlignment: GoogleAppsScript.Slides.ParagraphAlignment, verticalAlignment: GoogleAppsScript.Slides.ContentAlignment, bounds: ReturnType<typeof getBounds>, posOffset?: { dx: number; dy: number }) {
@@ -920,8 +965,10 @@ function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizont
   // content (dx>0 or dy>0). An equation at the very start of the box keeps the alignment-based
   // placement below, which is correct for a single centered/right-aligned equation.
   if (posOffset && (posOffset.dx > 0 || posOffset.dy > 0)) {
-    left = bounds.x + posOffset.dx;
-    top = bounds.y + posOffset.dy;
+    // add the box insets so the image lines up with the text's actual content origin, not the
+    // box's outer corner (this is what pulled images up-and-right of their source text).
+    left = bounds.x + BOX_LEFT_INSET_PT + posOffset.dx;
+    top = bounds.y + BOX_TOP_INSET_PT + posOffset.dy;
   } else {
     // horizontal: match the text alignment (box-edge / line-aware fallback)
     if (horizontalAlignment === SlidesApp.ParagraphAlignment.END)

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -24,7 +24,8 @@ interface DerenderData {
   pageElementId?: string,
   tableRow?: number,
   tableColumn?: number,
-  spaceCount?: number
+  spaceCount?: number,
+  spaceStart?: number
 }
 
 interface SlidesClientRenderOptions {
@@ -1249,7 +1250,8 @@ function placeImageAndFillSpaces(
     pageElementId: options.pageElementId,
     tableRow: options.tableRow,
     tableColumn: options.tableColumn,
-    spaceCount
+    spaceCount,
+    spaceStart: liveStart
   };
   image.setTitle(JSON.stringify(derenderData));
 
@@ -1310,19 +1312,17 @@ function clientRenderComplete(equations: SlidesClientRenderPayload[]): SlidesEqu
         const blob = Utilities.newBlob(Utilities.base64Decode(equation.renderedEquationB64), "image/png");
         const placed = placeImageAndFillSpaces(target, o, bounds, equationRange, liveStart, blob, { dx: posDx, dy: posDy, lineHeight });
 
-        cursor.x += placed.imageWidth;                                  // equation occupies its image width
-        liveDelta += placed.spaceCount - (o.rangeEnd - o.rangeStart);   // net length change from the space-fill
+        // REASON: advance by the GAP width (the spaces the box actually lays out), not the image
+        // width. If these differ, the next equation's image lands off its own gap (first-right /
+        // second-left). Keeping the cursor in lockstep with the box's spaces keeps them aligned.
+        cursor.x += placed.spaceCount * (glyphWidthEm(" ") * fontPt);
+        liveDelta += placed.spaceCount - (o.rangeEnd - o.rangeStart); // net length change from the space-fill
         prevEnd = o.rangeEnd;
         successCount++;
       }
-
-      // REASON: a box that is now only whitespace was a standalone equation box; drop it so the
-      // image floats on its own (the old behavior), instead of leaving an empty box behind.
-      if (!isTableCell(target.textElement) &&
-          target.textElement.getShapeType() === SlidesApp.ShapeType.TEXT_BOX &&
-          target.textRange.asRenderedString().trim().length === 0) {
-        target.textElement.remove();
-      }
+      // NOTE: we intentionally KEEP the box (even if it's now only spaces) so derender can restore
+      // the equation into its space gap. A standalone equation box just becomes an invisible
+      // spaces box behind the floating image.
     } catch (error) {
       console.error("MathJax Slides client render completion failed.", error);
     }
@@ -1506,20 +1506,32 @@ function derenderImage(image: GoogleAppsScript.Slides.Image, defaultDelim: AutoL
   return Common.DerenderResult.Success;
 }
 
-// Find a run of EXACTLY `count` consecutive spaces in boxText; returns its start offset or -1.
-function findSpaceGap(boxText: string, count: number): number {
+// Find where to reinsert an equation over its placeholder spaces. The `count` placeholder spaces
+// usually merge with the prose spaces that surrounded the equation, so the visible run is >= count.
+// Return the offset (within a run of >= count spaces) closest to the recorded hint, or -1.
+function findSpaceGap(boxText: string, count: number, hint: number): number {
+  let best = -1;
+  let bestDist = Infinity;
   let i = 0;
   while (i < boxText.length) {
     if (boxText.charAt(i) === " ") {
       let j = i;
       while (j < boxText.length && boxText.charAt(j) === " ") j++;
-      if (j - i === count) return i;
+      if (j - i >= count) {
+        // any offset in [i, j-count] can host the `count`-space placeholder; pick nearest the hint
+        const candidate = Math.max(i, Math.min(hint, j - count));
+        const dist = Math.abs(candidate - hint);
+        if (dist < bestDist) {
+          bestDist = dist;
+          best = candidate;
+        }
+      }
       i = j;
     } else {
       i++;
     }
   }
-  return -1;
+  return best;
 }
 
 // Resolve the TextRange of the box (shape or table cell) recorded in a space-fill DerenderData.
@@ -1546,7 +1558,7 @@ function restoreEquationIntoSpaceGap(
 ): boolean {
   const boxTextRange = resolveDerenderBoxTextRange(slide, derenderData);
   if (!boxTextRange) return false;
-  const gapStart = findSpaceGap(boxTextRange.asRenderedString(), derenderData.spaceCount as number);
+  const gapStart = findSpaceGap(boxTextRange.asRenderedString(), derenderData.spaceCount as number, derenderData.spaceStart ?? 0);
   if (gapStart < 0) return false;
 
   boxTextRange.getRange(gapStart, gapStart + (derenderData.spaceCount as number)).clear();

--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -940,8 +940,15 @@ function resize(eqnImage: GoogleAppsScript.Slides.Image, scale: number, horizont
       top = bounds.y + bounds.height / 2 - height / 2;
   }
 
-  // REASON: never let the image run off the right/bottom edge of the slide. Clamp to the page;
-  // overlapping another element is acceptable, disappearing off-slide is not (user spec).
+  // REASON: keep the image inside its own text box first — the inline estimate can overshoot the
+  // box's right/bottom edge (long lines, imperfect wrap estimate). Clamp so the image's far edge
+  // stays within the box; if the image is wider/taller than the box, pin it to the box's top-left
+  // (it will overflow, but starts in the right place).
+  left = Math.max(bounds.x, Math.min(left, bounds.x + bounds.width - width));
+  top = Math.max(bounds.y, Math.min(top, bounds.y + bounds.height - height));
+
+  // REASON: then the outer safety — never let the image run off the right/bottom edge of the
+  // slide. Overlapping another element is acceptable, disappearing off-slide is not (user spec).
   const presentation = SlidesApp.getActivePresentation();
   const slideWidth = presentation.getPageWidth();
   const slideHeight = presentation.getPageHeight();

--- a/Slides/Sidebar.html
+++ b/Slides/Sidebar.html
@@ -88,7 +88,7 @@
           <div id="button-container" class="button-container">
             <div id="button-row1" class="button-row1">
               <button id="insert-text" class="action button-in-row1">Render Equations</button>
-              <button id="edit-text" class="button-in-row1">De-render Equation</button>
+              <button id="edit-text" class="button-in-row1">De-render Selection</button>
               <!-- style ="margin: 0; right: 0;" -->
             </div>
             <div id="button-row1" class="button-row1">
@@ -114,7 +114,7 @@
           <label id="tips">
             <br />
             <b>Tips:</b> <br />
-            • Click image and "De-render Equation" to convert back to code. <br />
+            • Click image (or select several) and "De-render Selection" to convert back to code. <br />
             • Multiple equations are rendered on top of each other. Drag equations to reposition location. <br />
             • Use shift+enter instead of enter for newlines within multi-line equations.
             <!-- <br> • Click the sidebar and press ctrl+q to derender all equations. (beta) -->

--- a/Slides/Sidebar.ts
+++ b/Slides/Sidebar.ts
@@ -59,6 +59,8 @@ interface SlidesClientRenderOptions {
   tableColumn?: number;
   rangeStart: number;
   rangeEnd: number;
+  fontFamily?: string;
+  glyphWidths?: { [ch: string]: number };
 }
 
 interface SlidesClientEquationRenderResult {
@@ -100,6 +102,74 @@ declare function renderEquationPngWithMathJax(
   renderOptions: { equation: string; inline: boolean; size: number; r: number; g: number; b: number; bgR?: number; bgG?: number; bgB?: number },
   reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
 ): Promise<Blob>;
+
+// REASON: measure real per-glyph advance widths for a font via Canvas measureText, so the server
+// can position equation images exactly for ANY font instead of assuming Arial. Measured at a large
+// reference size and normalized to em. Google Fonts are loaded on demand (system fonts already
+// resolve). Falls back silently to the server's Arial table if a font can't be measured.
+const GLYPH_MEASURE_REF_PX = 200;
+const glyphMeasureCanvas = document.createElement("canvas");
+const glyphMeasureCtx = glyphMeasureCanvas.getContext("2d");
+const fontLoadPromises: { [family: string]: Promise<void> } = {};
+const glyphTableCache: { [family: string]: { [ch: string]: number } } = {};
+
+function ensureFontLoaded(family: string): Promise<void> {
+  if (fontLoadPromises[family]) return fontLoadPromises[family];
+  fontLoadPromises[family] = (async () => {
+    try {
+      await new Promise<void>(resolve => {
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = "https://fonts.googleapis.com/css2?family=" + encodeURIComponent(family) + ":wght@400;700&display=swap";
+        link.onload = () => resolve();
+        link.onerror = () => resolve(); // not a Google Font (system font) — measure the browser's copy
+        document.head.appendChild(link);
+      });
+      const fonts = (document as unknown as { fonts?: { load(f: string): Promise<unknown> } }).fonts;
+      if (fonts && fonts.load) {
+        await fonts.load('400 20px "' + family + '"').catch(() => undefined);
+      }
+    } catch (e) {
+      // fall back to whatever the browser already has
+    }
+  })();
+  return fontLoadPromises[family];
+}
+
+async function measureGlyphTable(family: string): Promise<{ [ch: string]: number }> {
+  if (glyphTableCache[family]) return glyphTableCache[family];
+  await ensureFontLoaded(family);
+  const table: { [ch: string]: number } = {};
+  if (glyphMeasureCtx) {
+    glyphMeasureCtx.font = GLYPH_MEASURE_REF_PX + 'px "' + family + '", sans-serif';
+    for (let code = 32; code <= 126; code++) {
+      const ch = String.fromCharCode(code);
+      table[ch] = glyphMeasureCtx.measureText(ch).width / GLYPH_MEASURE_REF_PX;
+    }
+  }
+  glyphTableCache[family] = table;
+  return table;
+}
+
+async function attachGlyphTables(equations: SlidesClientRenderOptions[]): Promise<void> {
+  const families: { [f: string]: boolean } = {};
+  for (const eq of equations) {
+    if (eq.fontFamily) families[eq.fontFamily] = true;
+  }
+  const tables: { [f: string]: { [ch: string]: number } } = {};
+  for (const family of Object.keys(families)) {
+    try {
+      tables[family] = await measureGlyphTable(family);
+    } catch (e) {
+      // leave unset -> server uses its Arial fallback for this font
+    }
+  }
+  for (const eq of equations) {
+    if (eq.fontFamily && tables[eq.fontFamily]) {
+      eq.glyphWidths = tables[eq.fontFamily];
+    }
+  }
+}
 
 async function renderMathJaxEquation(renderOptions: SlidesClientRenderOptions) {
   return renderEquationPngWithMathJax(renderOptions, reportMathJaxClientError);
@@ -284,9 +354,11 @@ function insertText(){
       // REASON: Carry forward any successes the server included with this ClientRender batch.
       mathJaxRenderedCount += result.successCount;
 
-      // REASON: Render equations independently. A single MathJax failure should not force
+      // REASON: measure the real per-font glyph widths (Canvas measureText) and attach them to each
+      // equation's options FIRST, so the server can position images exactly for any font (not just
+      // Arial). Then render each equation independently — a single MathJax failure must not force
       // the whole batch through legacy server renderers that cannot preserve Unicode text.
-      mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async eq => {
+      attachGlyphTables(equationsToRender).then(() => mapWithConcurrency(equationsToRender, MATHJAX_CONCURRENCY_LIMIT, async eq => {
         try {
           return {
             ok: true as const,
@@ -305,7 +377,7 @@ function insertText(){
             options: eq
           };
         }
-      })
+      }))
         .then(results => {
           const rendered = results
             .filter(result => result.ok)

--- a/Workspace/Code.ts
+++ b/Workspace/Code.ts
@@ -24,7 +24,7 @@ function generateWorkspaceHomepage(status: string, error: string | null = null) 
     ["All supported delimiters", "all"],
     ["\\[ ... \\]", "["],
     ["\\( ... \\)", "("],
-    ["$ ... $", "$"]
+    ["$ ... $ (Beta)", "$"]
   ];
   const renderers = [
     ["Automatic", "auto"],

--- a/Workspace/Docs.ts
+++ b/Workspace/Docs.ts
@@ -115,7 +115,12 @@ function findPos(index: number, delim: AutoLatexCommon.Delimiter, quality: numbe
   Common.debugLog(delim[2], " single escaped delimiters ", placeHolderEnd - placeHolderStart, " characters long");
 
   Common.reportDeltaTime(214);
-  if (placeHolderEnd - placeHolderStart == 2.0) {
+  // REASON: the inclusive span of an empty equation is exactly the two delimiters.
+  // The old `== 2` check classified every one-character `$...$` equation (`$1$`,
+  // `$x$`) as empty in the Workspace add-on, so its Card UI reported only the
+  // longer equations as rendered.
+  const isEmptyEquation = placeHolderEnd - placeHolderStart + 1 === 2 * delim[4];
+  if (isEmptyEquation) {
     // empty equation
     console.log("Empty equation! In index " + index + " and offset " + placeHolderStart);
     return [defaultSize, endElement]; // default behavior of placeImage

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/Divide-By-0/autolatex/issues"
   },
   "homepage": "https://github.com/Divide-By-0/autolatex#readme",
+  "scripts": {
+    "test": "node --test tests/*.test.js",
+    "test:docs": "node --test tests/docs-dollar-pairing.test.js"
+  },
   "devDependencies": {
     "@grimsteel/clasp-types": "^1.7.3",
     "@types/google-apps-script": "^1.0.73",

--- a/tests/docs-dollar-pairing.test.js
+++ b/tests/docs-dollar-pairing.test.js
@@ -1,0 +1,264 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const docsCodePath = process.env.AUTOLATEX_DOCS_CODE_PATH ||
+  path.join(__dirname, "..", "Docs", "Code.js");
+
+function createRangeElement(element, startOffset, endOffsetInclusive = startOffset, generation = 0) {
+  return {
+    generation,
+    getElement: () => element,
+    getStartOffset: () => startOffset,
+    getEndOffsetInclusive: () => endOffsetInclusive,
+  };
+}
+
+function loadDocsCode(paragraphTexts, delimiter) {
+  const elementTypes = {
+    BODY_SECTION: "BODY_SECTION",
+    FOOTER_SECTION: "FOOTER_SECTION",
+    FOOTNOTE_SECTION: "FOOTNOTE_SECTION",
+    HEADER_SECTION: "HEADER_SECTION",
+    PARAGRAPH: "PARAGRAPH",
+    TEXT: "TEXT",
+  };
+
+  const body = {
+    getType: () => elementTypes.BODY_SECTION,
+  };
+  const paragraphs = paragraphTexts.map((text, paragraphIndex) => {
+    const paragraph = {
+      getParent: () => body,
+      getType: () => elementTypes.PARAGRAPH,
+    };
+    const textElement = {
+      asText: () => textElement,
+      getBackgroundColor: () => null,
+      getFontSize: () => 11,
+      getForegroundColor: () => "#000000",
+      getParent: () => paragraph,
+      getText: () => text,
+      getType: () => elementTypes.TEXT,
+      paragraphIndex,
+    };
+    paragraph.getNumChildren = () => 1;
+    paragraph.getChild = () => textElement;
+    paragraph.textElement = textElement;
+    return paragraph;
+  });
+
+  body.getChildIndex = paragraph => paragraphs.indexOf(paragraph);
+  body.getParent = () => sectionRoot;
+
+  // REASON: adding a named range can invalidate RangeElement search results that were
+  // obtained before the document mutation. The production failure presents as an
+  // inclusive resume from that stale result: the just-used closing "$" is returned
+  // again and becomes the next opening delimiter. A current RangeElement resumes
+  // after its inclusive end, matching the findText(..., from) "next result" contract.
+  let documentGeneration = 0;
+  body.findText = (pattern, fromRange) => {
+    const token = pattern === delimiter[3] ? delimiter[1] : delimiter[0];
+    let paragraphIndex = 0;
+    let offset = 0;
+    if (fromRange) {
+      paragraphIndex = fromRange.getElement().paragraphIndex;
+      offset = fromRange.generation < documentGeneration
+        ? fromRange.getStartOffset()
+        : fromRange.getEndOffsetInclusive() + 1;
+    }
+
+    for (let index = paragraphIndex; index < paragraphs.length; index++) {
+      const text = paragraphs[index].textElement.getText();
+      const searchFrom = index === paragraphIndex ? offset : 0;
+      const matchOffset = text.indexOf(token, searchFrom);
+      if (matchOffset >= 0) {
+        return createRangeElement(
+          paragraphs[index].textElement,
+          matchOffset,
+          matchOffset + token.length - 1,
+          documentGeneration
+        );
+      }
+    }
+    return null;
+  };
+
+  const sectionRoot = {
+    getChild: index => index === 0 ? body : null,
+    getNumChildren: () => 1,
+  };
+
+  let namedRangeId = 0;
+  const document = {
+    addNamedRange: (_name, range) => {
+      documentGeneration++;
+      const stored = range.getRangeElements()[0];
+      const currentRangeElement = createRangeElement(
+        stored.getElement(),
+        stored.getStartOffset(),
+        stored.getEndOffsetInclusive(),
+        documentGeneration
+      );
+      return {
+        getId: () => `range-${++namedRangeId}`,
+        getRange: () => ({
+          getRangeElements: () => [currentRangeElement],
+        }),
+      };
+    },
+    getBody: () => body,
+    newRange: () => {
+      let rangeElement;
+      return {
+        addElement: (element, startOffset, endOffsetInclusive) => {
+          rangeElement = createRangeElement(
+            element,
+            startOffset,
+            endOffsetInclusive,
+            documentGeneration
+          );
+          return {
+            build: () => ({
+              getRangeElements: () => [rangeElement],
+            }),
+          };
+        },
+      };
+    },
+  };
+
+  const context = {
+    Common: {
+      assert: (condition, message) => assert.ok(condition, message),
+      debugLog: () => {},
+      getClientEquation: equation => decodeURIComponent(equation),
+      reEncode: equation => encodeURIComponent(equation),
+      reportDeltaTime: () => {},
+    },
+    DocumentApp: {
+      ElementType: elementTypes,
+      getActiveDocument: () => document,
+    },
+    console: {
+      error: () => {},
+      log: () => {},
+      warn: () => {},
+    },
+    decodeURIComponent,
+    encodeURIComponent,
+    escape,
+    Set,
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(docsCodePath, "utf8"), context, {
+    filename: docsCodePath,
+  });
+
+  return {
+    context,
+    delimiter,
+  };
+}
+
+const delimiters = {
+  doubleDollar: ["$$", "$$", "\\$\\$", "\\$\\$", 2, 1, 0],
+  brackets: ["\\[", "\\]", "\\\\\\[", "\\\\\\]", 2, 1, 1],
+  singleDollar: ["$", "$", "\\$", "\\$", 1, 0, 2],
+  parentheses: ["\\(", "\\)", "\\\\\\(", "\\\\\\)", 2, 1, 3],
+};
+
+function collectClientEquations(paragraphTexts, delimiter = delimiters.singleDollar) {
+  const { context } = loadDocsCode(paragraphTexts, delimiter);
+  const renderOptions = {
+    size: 11,
+    defaultSize: 11,
+    inline: false,
+    delim: delimiter,
+    clientRender: true,
+    autoFallbackToClient: false,
+    r: 0,
+    g: 0,
+    b: 0,
+  };
+
+  const equations = [];
+  let cursor = null;
+  for (let iteration = 0; iteration < 20; iteration++) {
+    const result = context.findPos(0, renderOptions, cursor);
+    if (result.status === 7 || result.status === 6) {
+      return equations;
+    }
+
+    assert.equal(result.status, 2, "expected a MathJax client-render result");
+    assert.ok(result.nextStartElement, "the batch scan must advance its cursor");
+    equations.push(result.clientRenderOptions.equation);
+    cursor = result.nextStartElement;
+  }
+
+  assert.fail("delimiter scan did not terminate");
+}
+
+test("MathJax batch keeps adjacent inline equations paired", () => {
+  assert.deepEqual(
+    collectClientEquations(["$1$ and $2$"]),
+    ["1", "2"],
+  );
+});
+
+test("single-dollar scanning does not consume double-dollar delimiters", () => {
+  assert.deepEqual(
+    collectClientEquations(["$$block$$ and $inline$"]),
+    ["inline"],
+  );
+});
+
+test("the cursor fix preserves double-dollar equation pairing", () => {
+  assert.deepEqual(
+    collectClientEquations(
+      ["Before $$a+b$$ between $$c$$ after"],
+      delimiters.doubleDollar,
+    ),
+    ["a+b", "c"],
+  );
+});
+
+test("the cursor fix preserves bracket-delimited equation pairing", () => {
+  assert.deepEqual(
+    collectClientEquations(
+      ["Before \\[a+b\\] between \\[c\\] after"],
+      delimiters.brackets,
+    ),
+    ["a+b", "c"],
+  );
+});
+
+test("the cursor fix preserves parenthesis-delimited equation pairing", () => {
+  assert.deepEqual(
+    collectClientEquations(
+      ["Before \\(a+b\\) between \\(c\\) after"],
+      delimiters.parentheses,
+    ),
+    ["a+b", "c"],
+  );
+});
+
+test("MathJax batch does not pair prose between currency-looking equations", () => {
+  assert.deepEqual(
+    collectClientEquations(["Render $10000$ don't render $2000$"]),
+    ["10000", "2000"],
+  );
+});
+
+test("MathJax batch preserves pairing across the two test-document paragraphs", () => {
+  assert.deepEqual(
+    collectClientEquations([
+      "Render $10000$ don't render $2000$",
+      "$1$ and $2$",
+    ]),
+    ["10000", "2000", "1", "2"],
+  );
+});

--- a/tests/docs-dollar-pairing.test.js
+++ b/tests/docs-dollar-pairing.test.js
@@ -7,9 +7,16 @@ const vm = require("node:vm");
 const docsCodePath = process.env.AUTOLATEX_DOCS_CODE_PATH ||
   path.join(__dirname, "..", "Docs", "Code.js");
 
-function createRangeElement(element, startOffset, endOffsetInclusive = startOffset, generation = 0) {
+// REASON: fromFind distinguishes a genuine findText() result from a range built by
+// newRange().addElement() or read back from a NamedRange. Real Docs continues findText(pattern,
+// from) STRICTLY AFTER a findText result's match, but from the START of a constructed range. That
+// difference is the whole bug: for single-`$` a constructed whole-equation range starts at the
+// opening delimiter, so the next search re-finds the equation's own closing `$` and pairs it
+// forward. Only resuming from the closing-delimiter findText result advances correctly.
+function createRangeElement(element, startOffset, endOffsetInclusive = startOffset, generation = 0, fromFind = false) {
   return {
     generation,
+    fromFind,
     getElement: () => element,
     getStartOffset: () => startOffset,
     getEndOffsetInclusive: () => endOffsetInclusive,
@@ -65,9 +72,12 @@ function loadDocsCode(paragraphTexts, delimiter) {
     let offset = 0;
     if (fromRange) {
       paragraphIndex = fromRange.getElement().paragraphIndex;
-      offset = fromRange.generation < documentGeneration
-        ? fromRange.getStartOffset()
-        : fromRange.getEndOffsetInclusive() + 1;
+      // Real Docs: continue AFTER a findText result's match, but from the START of a range that
+      // was constructed (newRange / NamedRange). +1 in both cases because the search is exclusive
+      // of the anchor position itself.
+      offset = fromRange.fromFind
+        ? fromRange.getEndOffsetInclusive() + 1
+        : fromRange.getStartOffset() + 1;
     }
 
     for (let index = paragraphIndex; index < paragraphs.length; index++) {
@@ -79,7 +89,8 @@ function loadDocsCode(paragraphTexts, delimiter) {
           paragraphs[index].textElement,
           matchOffset,
           matchOffset + token.length - 1,
-          documentGeneration
+          documentGeneration,
+          true // this is a genuine findText result
         );
       }
     }

--- a/tests/docs-dollar-pairing.test.js
+++ b/tests/docs-dollar-pairing.test.js
@@ -13,9 +13,8 @@ const docsCodePath = process.env.AUTOLATEX_DOCS_CODE_PATH ||
 // difference is the whole bug: for single-`$` a constructed whole-equation range starts at the
 // opening delimiter, so the next search re-finds the equation's own closing `$` and pairs it
 // forward. Only resuming from the closing-delimiter findText result advances correctly.
-function createRangeElement(element, startOffset, endOffsetInclusive = startOffset, generation = 0, fromFind = false) {
+function createRangeElement(element, startOffset, endOffsetInclusive = startOffset, fromFind = false) {
   return {
-    generation,
     fromFind,
     getElement: () => element,
     getStartOffset: () => startOffset,
@@ -60,12 +59,6 @@ function loadDocsCode(paragraphTexts, delimiter) {
   body.getChildIndex = paragraph => paragraphs.indexOf(paragraph);
   body.getParent = () => sectionRoot;
 
-  // REASON: adding a named range can invalidate RangeElement search results that were
-  // obtained before the document mutation. The production failure presents as an
-  // inclusive resume from that stale result: the just-used closing "$" is returned
-  // again and becomes the next opening delimiter. A current RangeElement resumes
-  // after its inclusive end, matching the findText(..., from) "next result" contract.
-  let documentGeneration = 0;
   body.findText = (pattern, fromRange) => {
     const token = pattern === delimiter[3] ? delimiter[1] : delimiter[0];
     let paragraphIndex = 0;
@@ -89,7 +82,6 @@ function loadDocsCode(paragraphTexts, delimiter) {
           paragraphs[index].textElement,
           matchOffset,
           matchOffset + token.length - 1,
-          documentGeneration,
           true // this is a genuine findText result
         );
       }
@@ -111,7 +103,6 @@ function loadDocsCode(paragraphTexts, delimiter) {
   const renderedSpans = [];
   const document = {
     addNamedRange: (_name, range) => {
-      documentGeneration++;
       const stored = range.getRangeElements()[0];
       renderedSpans.push({
         paragraphIndex: stored.getElement().paragraphIndex,
@@ -121,8 +112,7 @@ function loadDocsCode(paragraphTexts, delimiter) {
       const currentRangeElement = createRangeElement(
         stored.getElement(),
         stored.getStartOffset(),
-        stored.getEndOffsetInclusive(),
-        documentGeneration
+        stored.getEndOffsetInclusive()
       );
       return {
         getId: () => `range-${++namedRangeId}`,
@@ -139,8 +129,7 @@ function loadDocsCode(paragraphTexts, delimiter) {
           rangeElement = createRangeElement(
             element,
             startOffset,
-            endOffsetInclusive,
-            documentGeneration
+            endOffsetInclusive
           );
           return {
             build: () => ({

--- a/tests/docs-dollar-pairing.test.js
+++ b/tests/docs-dollar-pairing.test.js
@@ -205,6 +205,14 @@ function collectClientEquations(paragraphTexts, delimiter = delimiters.singleDol
       return equations;
     }
 
+    // EmptyEquation (3): truly-empty or whitespace-only span. replaceEquations() skips it and
+    // moves on; mirror that so these never appear in the rendered set.
+    if (result.status === 3) {
+      assert.ok(result.nextStartElement, "empty-equation skip must advance the cursor");
+      cursor = result.nextStartElement;
+      continue;
+    }
+
     assert.equal(result.status, 2, "expected a MathJax client-render result");
     assert.ok(result.nextStartElement, "the batch scan must advance its cursor");
     equations.push(result.clientRenderOptions.equation);
@@ -302,6 +310,11 @@ function renderThenDerender(paragraphTexts, delimiter = delimiters.singleDollar)
   for (let iteration = 0; iteration < 20; iteration++) {
     const result = context.findPos(0, renderOptions, cursor);
     if (result.status === 7 || result.status === 6) break;
+    if (result.status === 3) {
+      // EmptyEquation: not rendered, no image placed - skip it in the reconstruction too.
+      cursor = result.nextStartElement;
+      continue;
+    }
     assert.equal(result.status, 2, "expected a MathJax client-render result");
     // renderedSpans grows by exactly one entry per rendered equation, in call order.
     rendered.push({
@@ -346,4 +359,17 @@ test("render then de-render round-trips $1$ and $2$ unchanged", () => {
 test("render then de-render round-trips the two-paragraph test document unchanged", () => {
   const paragraphs = ["Render $10000$ don't render $2000$", "$1$ and $2$"];
   assert.equal(renderThenDerender(paragraphs), paragraphs.join("\n"));
+});
+
+// REASON: a $...$ whose content is only whitespace typesets to a 0x0 SVG and crashes the
+// client canvas (convertToBlob "OffscreenCanvas size is zero" -> "MathJax failed to render 1
+// equation"). It must be skipped like an empty equation, not queued for rendering. Real inputs:
+// a lone "\r" from an empty equation auto-merged across a paragraph break, or a "$ $" typo.
+test("whitespace-only single-dollar equations are skipped, not rendered", () => {
+  assert.deepEqual(collectClientEquations(["$1$ and $ $"]), ["1"]);
+});
+
+test("a carriage-return-only equation is skipped and does not break neighbours", () => {
+  assert.deepEqual(collectClientEquations(["before $\r$ after"]), []);
+  assert.deepEqual(collectClientEquations(["$x$ then $\r$ then $y$"]), ["x", "y"]);
 });

--- a/tests/docs-dollar-pairing.test.js
+++ b/tests/docs-dollar-pairing.test.js
@@ -92,10 +92,21 @@ function loadDocsCode(paragraphTexts, delimiter) {
   };
 
   let namedRangeId = 0;
+  // REASON: record the document-order span each rendered equation occupies so a test can
+  // reconstruct the de-render round-trip. De-render replaces every image with
+  // delimiter+equation+delimiter, so the reconstructed text must equal the original. The
+  // pairing bug renders the prose between two equations as its own image whose span abuts
+  // its neighbours, so de-rendering collides their delimiters into "$$".
+  const renderedSpans = [];
   const document = {
     addNamedRange: (_name, range) => {
       documentGeneration++;
       const stored = range.getRangeElements()[0];
+      renderedSpans.push({
+        paragraphIndex: stored.getElement().paragraphIndex,
+        start: stored.getStartOffset(),
+        end: stored.getEndOffsetInclusive(),
+      });
       const currentRangeElement = createRangeElement(
         stored.getElement(),
         stored.getStartOffset(),
@@ -161,6 +172,7 @@ function loadDocsCode(paragraphTexts, delimiter) {
   return {
     context,
     delimiter,
+    renderedSpans,
   };
 }
 
@@ -261,4 +273,77 @@ test("MathJax batch preserves pairing across the two test-document paragraphs", 
     ]),
     ["10000", "2000", "1", "2"],
   );
+});
+
+// REASON: reproduce the exact user-visible de-render symptom, not just the render pairing.
+// Render each equation, then de-render every image the way removeAll() does — replace the
+// image with delimiter[0] + storedEquation + delimiter[1], keeping the un-rendered text
+// between images. The reconstructed document must equal the original. Under the pairing
+// bug the prose between two equations is itself rendered, and its image span abuts both
+// neighbours, so de-rendering collapses their delimiters together:
+//   "Render $10000$ don't render $2000$"  ->  "Render $10000$$ don't render $$2000$"
+//   "$1$ and $2$"                          ->  "$1$$ and $$2$"
+function renderThenDerender(paragraphTexts, delimiter = delimiters.singleDollar) {
+  const { context, renderedSpans } = loadDocsCode(paragraphTexts, delimiter);
+  const renderOptions = {
+    size: 11,
+    defaultSize: 11,
+    inline: false,
+    delim: delimiter,
+    clientRender: true,
+    autoFallbackToClient: false,
+    r: 0,
+    g: 0,
+    b: 0,
+  };
+
+  const rendered = [];
+  let cursor = null;
+  for (let iteration = 0; iteration < 20; iteration++) {
+    const result = context.findPos(0, renderOptions, cursor);
+    if (result.status === 7 || result.status === 6) break;
+    assert.equal(result.status, 2, "expected a MathJax client-render result");
+    // renderedSpans grows by exactly one entry per rendered equation, in call order.
+    rendered.push({
+      ...renderedSpans[renderedSpans.length - 1],
+      eq: result.clientRenderOptions.equation,
+    });
+    cursor = result.nextStartElement;
+    if (rendered.length > 40) assert.fail("delimiter scan did not terminate");
+  }
+
+  // Reconstruct each paragraph: walk left to right, emitting the un-rendered text before
+  // each image, then delimiter+equation+delimiter for the image itself. slice() (not
+  // substring) so an abutting/overlapping image span yields "" rather than swapping args.
+  return paragraphTexts
+    .map((text, paragraphIndex) => {
+      const images = rendered
+        .filter(image => image.paragraphIndex === paragraphIndex)
+        .sort((a, b) => a.start - b.start);
+      let out = "";
+      let position = 0;
+      for (const image of images) {
+        out += text.slice(position, image.start);
+        out += delimiter[0] + image.eq + delimiter[1];
+        position = image.end + 1;
+      }
+      out += text.slice(position);
+      return out;
+    })
+    .join("\n");
+}
+
+test("render then de-render round-trips currency-looking equations unchanged", () => {
+  const original = "Render $10000$ don't render $2000$";
+  assert.equal(renderThenDerender([original]), original);
+});
+
+test("render then de-render round-trips $1$ and $2$ unchanged", () => {
+  const original = "$1$ and $2$";
+  assert.equal(renderThenDerender([original]), original);
+});
+
+test("render then de-render round-trips the two-paragraph test document unchanged", () => {
+  const paragraphs = ["Render $10000$ don't render $2000$", "$1$ and $2$"];
+  assert.equal(renderThenDerender(paragraphs), paragraphs.join("\n"));
 });

--- a/tests/mathjax-sidebar-runtime.test.js
+++ b/tests/mathjax-sidebar-runtime.test.js
@@ -1,0 +1,22 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildSidebarSource = fs.readFileSync(
+  path.join(__dirname, "..", "BuildSidebarJS.js"),
+  "utf8"
+);
+
+test("Docs and Slides sidebars use the MathJax release that fixes the Package getter crash", () => {
+  assert.match(
+    buildSidebarSource,
+    /https:\/\/cdn\.jsdelivr\.net\/npm\/mathjax@4\.1\.2\/tex-svg\.js/
+  );
+  assert.doesNotMatch(buildSidebarSource, /mathjax@3\/es5\/tex-svg\.js/);
+});
+
+test("the combined tex-svg component is not recursively loaded during startup", () => {
+  assert.match(buildSidebarSource, /loader:\s*\{\s*load:\s*\['\[tex\]\/color'\]\s*\}/);
+  assert.doesNotMatch(buildSidebarSource, /load:\s*\[[^\]]*['"]tex-svg['"]/);
+});

--- a/tests/single-dollar-beta-label.test.js
+++ b/tests/single-dollar-beta-label.test.js
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(__dirname, "..", relativePath), "utf8");
+}
+
+test("both Docs interfaces mark single-dollar delimiters as Beta without changing their value", () => {
+  assert.match(
+    read("Docs/Sidebar.html"),
+    /<option value="\$">\$ \.\.\. \$ \(Beta\)<\/option>/
+  );
+  assert.match(
+    read("Workspace/Code.ts"),
+    /\["\$ \.\.\. \$ \(Beta\)", "\$"\]/
+  );
+});

--- a/tests/workspace-dollar-pairing.test.js
+++ b/tests/workspace-dollar-pairing.test.js
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const workspaceDocsPath = path.join(__dirname, "..", "Workspace", "Docs.js");
+const singleDollarDelimiter = ["$", "$", "\\$", "\\$", 1, 0, 2];
+
+function exerciseWorkspaceFindPos(text) {
+  const textElement = { getText: () => text };
+  const rangeElement = offset => ({
+    getElement: () => textElement,
+    getStartOffset: () => offset,
+    getEndOffsetInclusive: () => offset,
+  });
+  const body = {
+    findText: (_pattern, fromRange) => {
+      const offset = text.indexOf("$", fromRange ? fromRange.getStartOffset() + 1 : 0);
+      return offset < 0 ? null : rangeElement(offset);
+    },
+  };
+  const context = {
+    Common: {
+      debugLog: () => {},
+      reportDeltaTime: () => {},
+    },
+    console: {
+      error: () => {},
+      log: () => {},
+      warn: () => {},
+    },
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(workspaceDocsPath, "utf8"), context, {
+    filename: workspaceDocsPath,
+  });
+
+  let placement;
+  context.getBodyFromIndex = () => body;
+  context.placeImage = (_startElement, start, end) => {
+    placement = { start, end };
+    return [11, null];
+  };
+
+  const result = context.findPos(0, singleDollarDelimiter, 900, 11, 11, true, null);
+  return { placement, result };
+}
+
+test("Workspace Card path sends one-character dollar equations to the renderer", () => {
+  assert.deepEqual(exerciseWorkspaceFindPos("$1$").placement, { start: 0, end: 2 });
+  assert.deepEqual(exerciseWorkspaceFindPos("$2$").placement, { start: 0, end: 2 });
+});
+
+test("Workspace Card path still skips a genuinely empty dollar equation", () => {
+  const { placement, result } = exerciseWorkspaceFindPos("$$");
+  assert.equal(placement, undefined);
+  assert.equal(result[0], 11);
+  assert.ok(result[1], "the scan should advance past the empty equation");
+});


### PR DESCRIPTION
Fixes three bugs that broke `$ ... $` (single-dollar) and Automatic/MathJax rendering in Docs (and the Workspace card). Reported symptoms: one-character equations like `$1$` not rendering, prose between equations rendering as bogus equations, and `Status: Error, please reload`.

## Issues fixed
1. **`$1$` / `$2$` skipped as "empty"** — `findPos` used `end - start == 2`, which is a *one-character* equation for single-dollar. Now `end - start + 1 === 2 * delim[4]` (correct for `$`, `$$`, `\[ \]`, `\( \)`).
2. **Prose rendered between equations** — the MathJax batch path defers text removal, so it must advance the scan itself. It resumed from the equation's *opening* delimiter; since `addNamedRange` invalidates earlier `RangeElement`s, `findText` re-found the *closing* delimiter and paired it with the next equation's opening one. `"$10000$ don't render $2000$"` rendered `" don't render "` as an equation, and de-render produced `"$10000$$ don't render $$2000$"`. Now we re-read the persisted `NamedRange` after the mutation and resume from that fresh whole-equation range.
3. **`Error, please reload`** — MathJax 3 crashes during config in the Apps Script sidebar iframe (`Cannot set property Package … which has only a getter`), aborting every client render. Pinned **MathJax 4.1.2** and stopped double-loading the combined `tex-svg` component.

Plus: label single-dollar as **`$ ... $ (Beta)`** in the Docs sidebar and Workspace card.

## Tests
Adds `tests/` (`node --test`, wired as `npm test`):
- `docs-dollar-pairing` — currency-prose, adjacent inline, two-paragraph, `$$`/`\[`/`\(` pairing. **Fails on pre-fix `Code.js`, passes after.**
- `workspace-dollar-pairing`, `single-dollar-beta-label`, `mathjax-sidebar-runtime` (asserts the 4.1.2 pin + no recursive `tex-svg` load).

All 12 pass.

## Deploy status
- **Docs project head is already pushed** with all three fixes (empty-eq + persisted-range + MathJax 4.1.2 sidebar). No version cut yet.
- ⚠️ **Slides sidebar still ships mathjax@3** and needs the same `BuildSidebarJS` rebuild + push, or Slides client rendering will still hit the getter crash. Not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)