### PR TITLE
[codex] Add MathJax symbol compatibility

### DIFF
--- a/BuildSidebarJS.js
+++ b/BuildSidebarJS.js
@@ -17,7 +17,13 @@ function getMathJaxSetup() {
   //     noindent/vspace are display no-ops
   //   - toprule/midrule/bottomrule cover ChatGPT-generated booktabs tables
   // configmacros (which reads 'macros'/'environments') and textmacros are already in
-  // tex-svg's default package set, so only 'color' needs explicit loading.
+  // tex-svg's default package set.
+  // REASON: preload the small upgreek, gensymb, and boldsymbol extensions. Their
+  // combined transfer is only a few kilobytes, and keeping the package list explicit
+  // is simpler and more deterministic than maintaining a second command-to-package
+  // autoload map. `bm` remains a compatibility spelling for the common LaTeX
+  // package's primary command; it delegates to MathJax's boldsymbol implementation
+  // rather than pretending to implement the full bm package.
   //
   // REASON: do not put the combined `tex-svg` component in loader.load. The component
   // is loaded directly by the script tag below; asking the loader to load it again
@@ -26,10 +32,11 @@ function getMathJaxSetup() {
   // tex2svgPromise existed.
   return `
 window.MathJax = {
-  loader: { load: ['[tex]/color'] },
+  loader: { load: ['[tex]/color', '[tex]/upgreek', '[tex]/gensymb', '[tex]/boldsymbol'] },
   tex: {
-    packages: { '[+]': ['color'] },
+    packages: { '[+]': ['color', 'upgreek', 'gensymb', 'boldsymbol'] },
     macros: {
+      bm: ['\\\\boldsymbol{#1}', 1],
       centering: '',
       caption: ['\\\\\\\\[0.5em]\\\\text{#1}', 1],
       label: ['', 1],

--- a/SidebarMathJaxShared.ts
+++ b/SidebarMathJaxShared.ts
@@ -159,6 +159,78 @@ function hasNonAsciiText(value: string) {
   return value.split("").some(char => char.charCodeAt(0) > 0x7F);
 }
 
+// REASON: Common.reEncode converts pasted Unicode Greek to unicode-math's
+// per-character \mup... commands so the legacy server renderers preserve upright
+// glyphs. MathJax 4 supports the base \mathup command but not those \mup... names.
+// They appeared 225 times in a 5,000-entry production error sample (not always as
+// the primary error), so translate the exact generated command set for the client
+// renderer. Unknown \mup... commands stay untouched instead of being guessed.
+const UNICODE_MATH_UPRIGHT_GREEK: Record<string, string> = {
+  mupAlpha: "Α",
+  mupBeta: "Β",
+  mupGamma: "Γ",
+  mupDelta: "Δ",
+  mupEpsilon: "Ε",
+  mupZeta: "Ζ",
+  mupEta: "Η",
+  mupTheta: "Θ",
+  mupIota: "Ι",
+  mupKappa: "Κ",
+  mupLambda: "Λ",
+  mupMu: "Μ",
+  mupNu: "Ν",
+  mupXi: "Ξ",
+  mupOmicron: "Ο",
+  mupPi: "Π",
+  mupRho: "Ρ",
+  mupSigma: "Σ",
+  mupTau: "Τ",
+  mupUpsilon: "Υ",
+  mupPhi: "Φ",
+  mupChi: "Χ",
+  mupPsi: "Ψ",
+  mupOmega: "Ω",
+  mupalpha: "α",
+  mupbeta: "β",
+  mupgamma: "γ",
+  mupdelta: "δ",
+  mupvarepsilon: "ε",
+  mupzeta: "ζ",
+  mupeta: "η",
+  muptheta: "θ",
+  mupiota: "ι",
+  mupkappa: "κ",
+  muplambda: "λ",
+  mupmu: "μ",
+  mupnu: "ν",
+  mupxi: "ξ",
+  mupomicron: "ο",
+  muppi: "π",
+  muprho: "ρ",
+  mupvarsigma: "ς",
+  mupsigma: "σ",
+  muptau: "τ",
+  mupupsilon: "υ",
+  mupvarphi: "φ",
+  mupchi: "χ",
+  muppsi: "ψ",
+  mupomega: "ω",
+  mupvartheta: "ϑ",
+  mupphi: "ϕ",
+  mupvarpi: "ϖ",
+  mupvarkappa: "ϰ",
+  mupvarrho: "ϱ",
+  mupvarTheta: "ϴ",
+  mupepsilon: "ϵ"
+};
+
+function normalizeUnicodeMathUprightGreek(equation: string) {
+  return equation.replace(/\\mup[A-Za-z]+/g, command => {
+    const symbol = UNICODE_MATH_UPRIGHT_GREEK[command.substring(1)];
+    return symbol ? `\\mathup{${symbol}}` : command;
+  });
+}
+
 // REASON: Newlines inside a \begin{...}\end{...} environment are cosmetic (pasted
 // LaTeX formatting) — turning them into \\ injected phantom rows into bmatrix/align
 // content. Depth-0 newlines adjacent to \begin/\end are also layout (pasted LaTeX
@@ -209,7 +281,7 @@ function replaceNewlinesDepthAware(equation: string) {
  * Returns the equation body (color prefix is applied by the caller).
  */
 function prepareEquationForMathJax(rawEquation: string) {
-  const preprocessed = rawEquation
+  const preprocessed = normalizeUnicodeMathUprightGreek(rawEquation)
     // Unicode text inside \mbox/\mathrm needs \text for MathJax's textmacros path
     .replace(/\\mbox\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)
     .replace(/\\mathrm\s*\{([^{}]*)\}/g, (match, text) => hasNonAsciiText(text) ? `\\text{${text}}` : match)

--- a/tests/mathjax-sidebar-runtime.test.js
+++ b/tests/mathjax-sidebar-runtime.test.js
@@ -2,11 +2,33 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
+const ts = require("typescript");
 
 const buildSidebarSource = fs.readFileSync(
   path.join(__dirname, "..", "BuildSidebarJS.js"),
   "utf8"
 );
+const sharedMathJaxSource = fs.readFileSync(
+  path.join(__dirname, "..", "SidebarMathJaxShared.ts"),
+  "utf8"
+);
+
+function prepareEquationForMathJax(equation) {
+  const transpiled = ts.transpileModule(sharedMathJaxSource, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText;
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(transpiled, context);
+  context.rawEquationForTest = equation;
+  return vm.runInContext(
+    "prepareEquationForMathJax(rawEquationForTest)",
+    context
+  );
+}
 
 test("Docs and Slides sidebars use the MathJax release that fixes the Package getter crash", () => {
   assert.match(
@@ -17,6 +39,36 @@ test("Docs and Slides sidebars use the MathJax release that fixes the Package ge
 });
 
 test("the combined tex-svg component is not recursively loaded during startup", () => {
-  assert.match(buildSidebarSource, /loader:\s*\{\s*load:\s*\['\[tex\]\/color'\]\s*\}/);
   assert.doesNotMatch(buildSidebarSource, /load:\s*\[[^\]]*['"]tex-svg['"]/);
+});
+
+test("small symbol packages are preloaded and bm delegates to boldsymbol", () => {
+  assert.ok(
+    buildSidebarSource.includes(
+      "loader: { load: ['[tex]/color', '[tex]/upgreek', '[tex]/gensymb', '[tex]/boldsymbol'] }"
+    ),
+    "the MathJax loader should preload the supported symbol extensions"
+  );
+  assert.ok(
+    buildSidebarSource.includes(
+      "packages: { '[+]': ['color', 'upgreek', 'gensymb', 'boldsymbol'] }"
+    ),
+    "the TeX package list should match the explicitly loaded extensions"
+  );
+  assert.doesNotMatch(buildSidebarSource, /autoload:\s*\{/);
+  assert.ok(
+    buildSidebarSource.includes("bm: ['\\\\\\\\boldsymbol{#1}', 1]"),
+    "\\bm should delegate to MathJax's boldsymbol implementation"
+  );
+});
+
+test("Unicode Greek emitted by Common is normalized to MathJax's upright base command", () => {
+  assert.equal(
+    prepareEquationForMathJax("\\mupalpha + \\mupvarepsilon + \\mupOmega"),
+    "\\mathup{α} + \\mathup{ε} + \\mathup{Ω}"
+  );
+  assert.equal(
+    prepareEquationForMathJax("\\mupNotARealSymbol"),
+    "\\mupNotARealSymbol"
+  );
 });


### PR DESCRIPTION
## What changed

- Preloads MathJax TeX extensions for `upgreek`, `gensymb`, and `boldsymbol` alongside `color`.
- Adds a `\bm` macro shim that delegates to MathJax's `\boldsymbol` support.
- Normalizes Unicode upright Greek commands emitted by `Common.reEncode` from `\mup...` names into MathJax-supported `\mathup{...}` expressions.
- Adds runtime tests covering the package preload, `\bm`, and upright Greek normalization.

## Why

AI-generated and pasted LaTeX commonly uses small symbol packages or Unicode-derived upright Greek commands. The server renderers tolerate more of these cases than the MathJax client path, so the MathJax path needs explicit compatibility handling.

## Validation

- `npm test`