### PR TITLE
Keep no-fill Slides MathJax images transparent

### DIFF
--- a/Slides/Code.ts
+++ b/Slides/Code.ts
@@ -60,6 +60,8 @@ interface SlidesClientRenderOptions {
   glyphWidths?: { [ch: string]: number };
 }
 
+type SlidesMathJaxBackgroundOptions = Pick<SlidesClientRenderOptions, "bgR" | "bgG" | "bgB">;
+
 interface SlidesClientRenderPayload {
   options: SlidesClientRenderOptions;
   renderedEquationB64: string;
@@ -406,11 +408,11 @@ function findAllClientRenderEquationsInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColorRaw = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
-    // REASON: a white / near-white background should render as transparent, not a baked white box.
-    // Otherwise every equation on a normal white slide gets an opaque rectangle. Only a genuinely
-    // colored highlight/fill is baked in.
-    const bgColor = bgColorRaw && !isNearWhite(bgColorRaw) ? bgColorRaw : null;
+    const backgroundOptions = getMathJaxBackgroundOptions(
+      textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd),
+      textElement,
+      slideNum
+    );
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
@@ -424,7 +426,7 @@ function findAllClientRenderEquationsInTextElement(
       r: textColor[0],
       g: textColor[1],
       b: textColor[2],
-      ...(bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}),
+      ...backgroundOptions,
       delim: renderOptions.delim,
       equation: clientEquation,
       equationLinkEncoded: encodeURIComponent(clientEquation),
@@ -635,17 +637,36 @@ function getBgRgbColor(textRange: GoogleAppsScript.Slides.TextRange, slideNum: n
   ];
 }
 
+// REASON: absence of bgR/bgG/bgB is the client renderer's transparency contract.
+// A no-fill box must therefore return an empty object, not white sentinel values;
+// the shared canvas renderer fills the whole PNG whenever bgR is present.
+// White/near-white also stays unspecified: treating a normal white slide as a
+// background previously put an opaque rectangle behind every equation.
+function getMathJaxBackgroundOptions(
+  textRange: GoogleAppsScript.Slides.TextRange,
+  textElement: PageElement,
+  slideNum: number
+): SlidesMathJaxBackgroundOptions {
+  const bgColor = getBgRgbColor(textRange, slideNum) || getShapeFillRgbColor(textElement, slideNum);
+  if (!bgColor || isNearWhite(bgColor)) {
+    return {};
+  }
+  return { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] };
+}
+
 // REASON: rendering deletes the equation's text box when the equation was its only
 // content — taking the box's fill with it — and oversized equations overflow the
 // box anyway (user report: image doesn't fit, box gone, background lost). Bake the
 // box/cell SOLID fill into the image when the text has no explicit highlight.
 // Gradient/image fills can't be represented by one color; those stay transparent.
+// FillType.NONE, an invisible fill, or alpha 0 all mean there is no background and
+// must remain null so bgR/bgG/bgB are omitted from the MathJax payload.
 function getShapeFillRgbColor(element: PageElement, slideNum: number): [number, number, number] | null {
   try {
     const fill = element.getFill();
-    if (!fill) return null;
+    if (!fill || !fill.isVisible()) return null;
     const solid = fill.getSolidFill();
-    if (!solid) return null;
+    if (!solid || solid.getAlpha() <= 0) return null;
     let color = solid.getColor();
     if (color.getColorType() !== SlidesApp.ColorType.RGB) {
       const slide = IntegratedApp.getBody()[slideNum];
@@ -809,11 +830,11 @@ function findClientRenderEquationInTextElement(
     const size = getSlideTextSize(renderOptions.size, renderOptions.defaultSize, equationRange);
     const colorRangeEnd = Math.max(equationOffsets.start + renderOptions.delim[4], equationOffsets.end);
     const textColor = getRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum);
-    const bgColorRaw = getBgRgbColor(textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd), slideNum) || getShapeFillRgbColor(textElement, slideNum);
-    // REASON: a white / near-white background should render as transparent, not a baked white box.
-    // Otherwise every equation on a normal white slide gets an opaque rectangle. Only a genuinely
-    // colored highlight/fill is baked in.
-    const bgColor = bgColorRaw && !isNearWhite(bgColorRaw) ? bgColorRaw : null;
+    const backgroundOptions = getMathJaxBackgroundOptions(
+      textRange.getRange(equationOffsets.start + renderOptions.delim[4], colorRangeEnd),
+      textElement,
+      slideNum
+    );
     // REASON: collapse the encoded four-backslash newline marker in ENCODED space
     // (like the Codecogs path); the old decoded-space `.replace(/\\\\/g, "\\")`
     // halved every backslash pair and broke "\\\hline" in tables ("Misplaced
@@ -827,7 +848,7 @@ function findClientRenderEquationInTextElement(
       r: textColor[0],
       g: textColor[1],
       b: textColor[2],
-      ...(bgColor ? { bgR: bgColor[0], bgG: bgColor[1], bgB: bgColor[2] } : {}),
+      ...backgroundOptions,
       delim: renderOptions.delim,
       equation: clientEquation,
       equationLinkEncoded: encodeURIComponent(clientEquation),

--- a/tests/slides-mathjax-background.test.js
+++ b/tests/slides-mathjax-background.test.js
@@ -1,0 +1,146 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+const ts = require("typescript");
+
+const slidesTypeScriptSource = fs.readFileSync(
+  path.join(__dirname, "..", "Slides", "Code.ts"),
+  "utf8"
+);
+const slidesSource = ts.transpileModule(slidesTypeScriptSource, {
+  compilerOptions: { target: ts.ScriptTarget.ES2020 },
+}).outputText;
+
+function extractFunction(name) {
+  const start = slidesSource.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `missing ${name} in compiled Slides code`);
+  const bodyStart = slidesSource.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < slidesSource.length; index++) {
+    if (slidesSource[index] === "{") depth++;
+    if (slidesSource[index] === "}") depth--;
+    if (depth === 0) return slidesSource.slice(start, index + 1);
+  }
+  throw new Error(`unterminated ${name} function`);
+}
+
+function createRuntime() {
+  const context = {
+    console,
+    IntegratedApp: {
+      getBody() {
+        throw new Error("theme-color resolution is not used by these RGB fixtures");
+      },
+    },
+    SlidesApp: {
+      ColorType: { RGB: "RGB" },
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(
+    [
+      "getBgRgbColor",
+      "getShapeFillRgbColor",
+      "isNearWhite",
+      "getMathJaxBackgroundOptions",
+    ].map(extractFunction).join("\n"),
+    context
+  );
+  return context;
+}
+
+function rgbColor(red, green, blue) {
+  return {
+    getColorType: () => "RGB",
+    asRgbColor: () => ({
+      getRed: () => red,
+      getGreen: () => green,
+      getBlue: () => blue,
+    }),
+  };
+}
+
+function textRange(backgroundColor) {
+  return {
+    getTextStyle: () => ({
+      getBackgroundColor: () => backgroundColor,
+    }),
+  };
+}
+
+function pageElement(fill) {
+  return { getFill: () => fill };
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("Slides MathJax omits background fields for a box with no visible fill", () => {
+  const runtime = createRuntime();
+  const noFill = {
+    isVisible: () => false,
+    getSolidFill: () => {
+      throw new Error("an invisible fill must not be sampled as white");
+    },
+  };
+
+  const options = runtime.getMathJaxBackgroundOptions(
+    textRange(null),
+    pageElement(noFill),
+    0
+  );
+
+  assert.deepEqual(plain(options), {});
+  assert.equal(Object.hasOwn(options, "bgR"), false);
+  assert.equal(Object.hasOwn(options, "bgG"), false);
+  assert.equal(Object.hasOwn(options, "bgB"), false);
+});
+
+test("Slides MathJax omits background fields for an alpha-zero solid fill", () => {
+  const runtime = createRuntime();
+  const transparentSolid = {
+    isVisible: () => true,
+    getSolidFill: () => ({
+      getAlpha: () => 0,
+      getColor: () => rgbColor(20, 40, 60),
+    }),
+  };
+
+  const options = runtime.getMathJaxBackgroundOptions(
+    textRange(null),
+    pageElement(transparentSolid),
+    0
+  );
+
+  assert.deepEqual(plain(options), {});
+});
+
+test("Slides MathJax still bakes a genuinely colored opaque background", () => {
+  const runtime = createRuntime();
+  const coloredSolid = {
+    isVisible: () => true,
+    getSolidFill: () => ({
+      getAlpha: () => 1,
+      getColor: () => rgbColor(20, 40, 60),
+    }),
+  };
+
+  const options = runtime.getMathJaxBackgroundOptions(
+    textRange(null),
+    pageElement(coloredSolid),
+    0
+  );
+
+  assert.deepEqual(plain(options), { bgR: 20, bgG: 40, bgB: 60 });
+});
+
+test("both Slides MathJax extraction paths use the background-options gate", () => {
+  assert.equal(
+    (slidesTypeScriptSource.match(/const backgroundOptions = getMathJaxBackgroundOptions\(/g) || []).length,
+    2
+  );
+  assert.equal((slidesTypeScriptSource.match(/\.\.\.backgroundOptions/g) || []).length, 2);
+});


### PR DESCRIPTION
## Human intent

Rephrased from the user request and material follow-ups:

- Slides MathJax equations in boxes without a background must remain transparent, never gain a white rectangle.
- Represent no background by omitting the background fields entirely, matching the earlier transparent rendering contract.
- Preserve intentional opaque colored highlights and fills.

## Summary

- centralize Slides MathJax background serialization behind one helper used by both batch and one-at-a-time extraction
- treat invisible fills and alpha-zero solid fills as no background
- return an empty background-options object so `bgR`, `bgG`, and `bgB` are absent and the canvas remains transparent
- retain colored opaque-fill behavior and the existing white/near-white transparency rule

## Root cause

The existing shape-fill fallback called `getSolidFill()` without first checking fill visibility or alpha. A transparent/no-fill box could therefore be sampled as a white solid color, which serialized `bgR/bgG/bgB`; the shared renderer interprets the presence of `bgR` as an instruction to fill the entire PNG.

## Validation

- `node --test tests/slides-mathjax-background.test.js` (4 passing)
- `npm run build --workspace Workspace && npm test` (23 passing)
- focused Slides server TypeScript compile with `skipLibCheck`
- `git diff --check`

## Deployment impact

No deployment or Marketplace release is included. The change must be merged and released as a new Slides Apps Script version before installed users receive it.