### PR TITLE
Preserve LaTeX when Google Docs image insertion fails

### DIFF
--- a/Docs/Code.js
+++ b/Docs/Code.js
@@ -934,14 +934,15 @@ function placeImage(startElement, renderedEquation, renderer, equation, size, de
     if (text.length - 1 < endLimit)
         endLimit = text.length - 1;
     textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
-    Common.reportDeltaTime(522);
-    textElement.editAsText().deleteText(startOffset, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
-    Common.reportDeltaTime(526);
-    // try inserting twice
+    var insertedImage = null;
+    // REASON: Insert the rendered image before deleting any source text. Google Docs can
+    // transiently reject insertInlineImage with "Service unavailable: Documents"; the old
+    // order had already deleted the equation and its trailing text by then, so both retries
+    // left the user's LaTeX missing. Keeping the source intact makes insertion failures safe.
     for (var tryNum = 1; tryNum <= 2; tryNum++) {
         try {
-            paragraph.insertInlineImage(childIndex + 1, renderedEquation); // TODO ISSUE: sometimes fails because it times out and yeets
-            return repairImage(paragraph, childIndex, size, renderer, delim, textCopy, renderedEquation, equation);
+            insertedImage = paragraph.insertInlineImage(childIndex + 1, renderedEquation);
+            break;
         }
         catch (err) {
             console.log("Could not insert image try ".concat(tryNum));
@@ -949,9 +950,34 @@ function placeImage(startElement, renderedEquation, renderer, equation, size, de
             Utilities.sleep(1000);
         }
     }
-    throw new Error("Could not insert image at childindex!");
+    if (!insertedImage) {
+        throw new Error("Could not insert image at childindex; original LaTeX was preserved.");
+    }
+    var result;
+    try {
+        // Configure and size the image while the source equation is still present. Only
+        // commit the text replacement after all image-side operations have succeeded.
+        result = repairImage(paragraph, childIndex, size, renderer, delim, renderedEquation, equation);
+    }
+    catch (err) {
+        // REASON: If image configuration fails, remove the uncommitted image and leave the
+        // original equation untouched. Cleanup itself is best-effort during a Docs outage.
+        try {
+            insertedImage.removeFromParent();
+        }
+        catch (cleanupErr) {
+            console.error("Could not remove an uncommitted equation image.", cleanupErr);
+        }
+        throw err;
+    }
+    Common.reportDeltaTime(522);
+    textElement.editAsText().deleteText(startOffset, text.length - 1);
+    Common.reportDeltaTime(526);
+    if (textCopy.getText() != "")
+        paragraph.insertText(childIndex + 2, textCopy); // reinsert text after the image, with all the formatting
+    return result;
 }
-function repairImage(paragraph, childIndex, size, renderer, delim, textCopy, resp, equationOriginal) {
+function repairImage(paragraph, childIndex, size, renderer, delim, resp, equationOriginal) {
     var attemptsToSetImageUrl = 3;
     Common.reportDeltaTime(552); // 3 seconds!! inserting an inline image takes time
     while (attemptsToSetImageUrl > 0) {
@@ -972,8 +998,6 @@ function repairImage(paragraph, childIndex, size, renderer, delim, textCopy, res
         }
     }
     Common.reportDeltaTime(570);
-    if (textCopy.getText() != "")
-        paragraph.insertText(childIndex + 2, textCopy); // reinsert deleted text after the image, with all the formatting
     var height = paragraph.getChild(childIndex + 1).asInlineImage().getHeight();
     var width = paragraph.getChild(childIndex + 1).asInlineImage().getWidth();
     Common.debugLog("Pre-fixing size, width, height: " + size + ", " + width + ", " + height); //only a '1' is rendered as a 100 height (as of 10/20/19, now it is fetched as 90 height). putting an equationrendertime here just doesnt work

--- a/Docs/Code.ts
+++ b/Docs/Code.ts
@@ -1092,15 +1092,16 @@ function placeImage(startElement: GoogleAppsScript.Document.RangeElement, render
   let endLimit = endOffsetInclusive;
   if (text.length - 1 < endLimit) endLimit = text.length - 1;
   textCopy.asText().editAsText().deleteText(0, endLimit); // the copy only has the stuff after the equation
-  Common.reportDeltaTime(522);
-  textElement.editAsText().deleteText(startOffset, text.length - 1); // from the original, yeet the equation and all the remaining text so its possible to insert the equation (try moving after the equation insertion?)
-  Common.reportDeltaTime(526);
-  
-  // try inserting twice
+  let insertedImage: GoogleAppsScript.Document.InlineImage | null = null;
+
+  // REASON: Insert the rendered image before deleting any source text. Google Docs can
+  // transiently reject insertInlineImage with "Service unavailable: Documents"; the old
+  // order had already deleted the equation and its trailing text by then, so both retries
+  // left the user's LaTeX missing. Keeping the source intact makes insertion failures safe.
   for (let tryNum = 1; tryNum <= 2; tryNum++) {
     try {
-      paragraph.insertInlineImage(childIndex + 1, renderedEquation); // TODO ISSUE: sometimes fails because it times out and yeets
-      return repairImage(paragraph, childIndex, size, renderer, delim, textCopy, renderedEquation, equation);
+      insertedImage = paragraph.insertInlineImage(childIndex + 1, renderedEquation);
+      break;
     } catch (err) {
       console.log(`Could not insert image try ${tryNum}`);
       console.error(err);
@@ -1109,10 +1110,34 @@ function placeImage(startElement: GoogleAppsScript.Document.RangeElement, render
     }
   }
 
-  throw new Error("Could not insert image at childindex!");
+  if (!insertedImage) {
+    throw new Error("Could not insert image at childindex; original LaTeX was preserved.");
+  }
+
+  let result: DocsEquationRenderResult;
+  try {
+    // Configure and size the image while the source equation is still present. Only
+    // commit the text replacement after all image-side operations have succeeded.
+    result = repairImage(paragraph, childIndex, size, renderer, delim, renderedEquation, equation);
+  } catch (err) {
+    // REASON: If image configuration fails, remove the uncommitted image and leave the
+    // original equation untouched. Cleanup itself is best-effort during a Docs outage.
+    try {
+      insertedImage.removeFromParent();
+    } catch (cleanupErr) {
+      console.error("Could not remove an uncommitted equation image.", cleanupErr);
+    }
+    throw err;
+  }
+
+  Common.reportDeltaTime(522);
+  textElement.editAsText().deleteText(startOffset, text.length - 1);
+  Common.reportDeltaTime(526);
+  if (textCopy.getText() != "") paragraph.insertText(childIndex + 2, textCopy); // reinsert text after the image, with all the formatting
+  return result;
 }
 
-function repairImage(paragraph: GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph, childIndex: number, size:  number, renderer: AutoLatexCommon.Renderer, delim: AutoLatexCommon.Delimiter, textCopy: GoogleAppsScript.Document.Text, resp: GoogleAppsScript.Base.Blob, equationOriginal: string): DocsEquationRenderResult {
+function repairImage(paragraph: GoogleAppsScript.Document.ListItem | GoogleAppsScript.Document.Paragraph, childIndex: number, size:  number, renderer: AutoLatexCommon.Renderer, delim: AutoLatexCommon.Delimiter, resp: GoogleAppsScript.Base.Blob, equationOriginal: string): DocsEquationRenderResult {
   let attemptsToSetImageUrl = 3;
   Common.reportDeltaTime(552); // 3 seconds!! inserting an inline image takes time
   while (attemptsToSetImageUrl > 0) {
@@ -1133,7 +1158,6 @@ function repairImage(paragraph: GoogleAppsScript.Document.ListItem | GoogleAppsS
   }
 
   Common.reportDeltaTime(570);
-  if (textCopy.getText() != "") paragraph.insertText(childIndex + 2, textCopy); // reinsert deleted text after the image, with all the formatting
   const height = paragraph.getChild(childIndex + 1).asInlineImage().getHeight();
   const width = paragraph.getChild(childIndex + 1).asInlineImage().getWidth();
   Common.debugLog("Pre-fixing size, width, height: " + size + ", " + width + ", " + height); //only a '1' is rendered as a 100 height (as of 10/20/19, now it is fetched as 90 height). putting an equationrendertime here just doesnt work

--- a/tests/docs-image-placement-safety.test.js
+++ b/tests/docs-image-placement-safety.test.js
@@ -1,0 +1,66 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const docsCodePath = path.join(__dirname, "..", "Docs", "Code.js");
+
+function makeText(initialText, parent) {
+  const text = {
+    value: initialText,
+    asText: () => text,
+    copy: () => makeText(text.value, null),
+    editAsText: () => text,
+    getParent: () => parent,
+    getText: () => text.value,
+    deleteText(start, endInclusive) {
+      text.value = text.value.slice(0, start) + text.value.slice(endInclusive + 1);
+      return text;
+    },
+  };
+  return text;
+}
+
+test("placeImage preserves LaTeX when Google Docs rejects image insertion", () => {
+  const source = "Before $$x$$ after";
+  let deleteCalls = 0;
+  const paragraph = {
+    getChildIndex: child => child === text ? 0 : -1,
+    getParent: () => null,
+    insertInlineImage() {
+      throw new Error("Service unavailable: Documents");
+    },
+  };
+  const text = makeText(source, paragraph);
+  const originalDeleteText = text.deleteText;
+  text.deleteText = (start, endInclusive) => {
+    deleteCalls++;
+    return originalDeleteText(start, endInclusive);
+  };
+
+  const context = {
+    Common: { reportDeltaTime: () => {} },
+    Set,
+    Utilities: { sleep: () => {} },
+    console: { error: () => {}, log: () => {}, warn: () => {} },
+    escape,
+  };
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(docsCodePath, "utf8"), context, {
+    filename: docsCodePath,
+  });
+
+  const span = {
+    getElement: () => text,
+    getStartOffset: () => 7,
+    getEndOffsetInclusive: () => 11,
+  };
+
+  assert.throws(
+    () => context.placeImage(span, {}, [0, "", "", "", "", "MathJax"], "x", 11, ["$$", "$$", "", "", 2, 1, 0]),
+    /original LaTeX was preserved/,
+  );
+  assert.equal(text.getText(), source);
+  assert.equal(deleteCalls, 0);
+});


### PR DESCRIPTION
## Human intent

Rephrased from the user's request and material follow-ups:

- Fix document-specific rendering failures that make existing LaTeX disappear without rendered equations.
- Preserve large documents' original equation source so users never have to reconstruct it manually after a transient failure.

## Root cause

The supplied temporary user key correlates with repeated `Service unavailable: Documents` errors from `insertInlineImage`. The Docs integration deleted each equation and its trailing text before attempting that fallible call, so both retries could fail after the source was already gone. MathJax itself completed successfully.

## Change

- Insert and configure the equation image before mutating source text.
- Remove an uncommitted image if its configuration fails, leaving the LaTeX intact.
- Add a regression test that simulates a Google Docs insertion outage and asserts no source deletion occurs.

## Validation

- `node --test tests/docs-image-placement-safety.test.js`
- `tsc Docs/Code.ts --noEmit --target ES5 --module none --lib DOM,ES6,ES2016,ES2017,ES2018 --typeRoots ./node_modules/@types,./types --skipLibCheck`
- Full `npm test`: 18 pass; the two existing Workspace tests fail because `Workspace/Docs.js` is an intentionally untracked generated file and is absent in a clean checkout.

## Rollout

This PR changes source and compiled Apps Script code only. It has not been pushed to Apps Script or published to Marketplace.