### PR TITLE
Prevent stalled MathJax renders from hanging

### DIFF
--- a/Docs/Sidebar.ts
+++ b/Docs/Sidebar.ts
@@ -228,6 +228,7 @@ declare function renderEquationPngWithMathJax(
   renderOptions: { equation: string; inline: boolean; size: number; r: number; g: number; b: number; bgR?: number; bgG?: number; bgB?: number },
   reportError?: (context: string, error: unknown, extra?: Record<string, unknown>) => void
 ): Promise<Blob>;
+declare function getMathJaxTimeoutErrorMessage(errors: unknown[]): string | null;
 
 async function renderMathJaxEquation(renderOptions: AutoLatexCommon.ClientRenderOptions) {
   return renderEquationPngWithMathJax(renderOptions, reportMathJaxClientError);
@@ -424,7 +425,8 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
         });
         return {
           ok: false as const,
-          options: c
+          options: c,
+          error: err
         };
       }
     })
@@ -438,6 +440,9 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
         const failed = results
           .filter(result => !result.ok)
           .map(result => ({ options: result.options }));
+        const timeoutErrorMessage = getMathJaxTimeoutErrorMessage(
+          results.filter(result => !result.ok).map(result => result.error)
+        );
 
         // REASON: In auto mode, equations MathJax couldn't render fall back to the
         // server-side renderers (Texrendr/Sciweavers) per equation, so one bad
@@ -454,7 +459,11 @@ function successHandler({ lastStatus, successCount, clientEquations, autoFixedCo
               .withUserObject(element)
               .clientRenderFailed(failed);
           } else {
-            errorHandler(new Error(`MathJax failed to render ${failed.length} equation(s).`), element, actionId);
+            errorHandler(
+              new Error(timeoutErrorMessage || `MathJax failed to render ${failed.length} equation(s).`),
+              element,
+              actionId
+            );
           }
         };
 

--- a/SidebarMathJaxShared.ts
+++ b/SidebarMathJaxShared.ts
@@ -6,10 +6,13 @@
 // project-specific references — it must compile standalone and run inside every
 // sidebar's sandboxed iframe.
 
-declare const MathJax: {
-  tex2svgPromise(equation: string, options: { display: boolean, em: number }): Promise<Element>;
-  svgStylesheet(): Element;
-};
+interface SharedMathJaxApi {
+  tex2svgPromise?: (equation: string, options: { display: boolean, em: number }) => Promise<Element>;
+  svgStylesheet?: () => Element;
+  startup?: {
+    promise?: Promise<unknown>;
+  };
+}
 
 interface SharedMathJaxRenderOptions {
   equation: string;
@@ -26,6 +29,178 @@ interface SharedMathJaxRenderOptions {
 // REASON: MathJax rendering is CPU-heavy (SVG → canvas → PNG). Running too many in
 // parallel (e.g. 1000 equations) would freeze the browser; this caps concurrency.
 const MATHJAX_CONCURRENCY_LIMIT = 4;
+
+// REASON: MathJax 4's startup can leave its promise pending forever when a bundled
+// worker fails to load in the Apps Script iframe. Keep startup's deadline short
+// because it is independent of equation complexity. Typesetting and rasterization
+// get a separate equation-scaled budget below so a large, valid equation is not
+// mistaken for the startup deadlock.
+const MATHJAX_STARTUP_TIMEOUT_MS = 30000;
+const MATHJAX_EQUATION_BASE_TIMEOUT_MS = 120000;
+const MATHJAX_EQUATION_TIMEOUT_PER_CHARACTER_MS = 250;
+const MATHJAX_EQUATION_MAX_TIMEOUT_MS = 15 * 60 * 1000;
+let mathJaxStartupWait: Promise<SharedMathJaxApi> | null = null;
+let mathJaxReadyInstance: SharedMathJaxApi | null = null;
+
+class MathJaxTimeoutError extends Error {
+  constructor(readonly stage: string, readonly timeoutMs: number) {
+    super(`MathJax stopped responding while ${stage}. Try again, or use Automatic/Texrendr.`);
+    this.name = "MathJaxTimeoutError";
+  }
+}
+
+function getMathJaxTimeoutErrorMessage(errors: unknown[]) {
+  const timeoutError = errors.find(error =>
+    typeof error === "object"
+      && error !== null
+      && (error as { name?: string }).name === "MathJaxTimeoutError"
+  ) as { message?: string } | undefined;
+  return timeoutError?.message || null;
+}
+
+function getMathJaxEquationTimeoutMs(equationLength: number) {
+  const safeLength = Number.isFinite(equationLength) ? Math.max(0, equationLength) : 0;
+  return Math.min(
+    MATHJAX_EQUATION_MAX_TIMEOUT_MS,
+    MATHJAX_EQUATION_BASE_TIMEOUT_MS + safeLength * MATHJAX_EQUATION_TIMEOUT_PER_CHARACTER_MS
+  );
+}
+
+function withMathJaxTimeout<T>(promise: PromiseLike<T>, timeoutMs: number, stage: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timerId = window.setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        reject(new MathJaxTimeoutError(stage, timeoutMs));
+      }
+    }, timeoutMs);
+
+    Promise.resolve(promise).then(
+      value => {
+        if (!settled) {
+          settled = true;
+          window.clearTimeout(timerId);
+          resolve(value);
+        }
+      },
+      error => {
+        if (!settled) {
+          settled = true;
+          window.clearTimeout(timerId);
+          reject(error);
+        }
+      }
+    );
+  });
+}
+
+function isMathJaxReady(mathJaxGlobal: SharedMathJaxApi | undefined): mathJaxGlobal is Required<Pick<SharedMathJaxApi, "tex2svgPromise" | "svgStylesheet">> & SharedMathJaxApi {
+  return typeof mathJaxGlobal?.tex2svgPromise === "function"
+    && typeof mathJaxGlobal.svgStylesheet === "function";
+}
+
+function getMathJaxGlobal() {
+  return (window as unknown as { MathJax?: SharedMathJaxApi }).MathJax;
+}
+
+async function waitForMathJaxStartupInternal(timeoutMs: number): Promise<SharedMathJaxApi> {
+  const startedAt = Date.now();
+  let mathJaxGlobal = getMathJaxGlobal();
+  // REASON: tex2svgPromise/svgStylesheet may be installed before MathJax's startup
+  // promise settles. The SRE worker failure observed in production happens in that
+  // interval, so the presence of those methods alone must not bypass the startup
+  // deadline.
+  if (mathJaxGlobal?.startup?.promise) {
+    await withMathJaxTimeout(mathJaxGlobal.startup.promise, timeoutMs, "starting");
+    mathJaxGlobal = getMathJaxGlobal();
+    if (isMathJaxReady(mathJaxGlobal)) {
+      return mathJaxGlobal;
+    }
+  } else if (isMathJaxReady(mathJaxGlobal)) {
+    return mathJaxGlobal;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let timerId: number | undefined;
+    let watchedScript: HTMLScriptElement | null = null;
+
+    const cleanup = () => {
+      if (timerId !== undefined) {
+        window.clearTimeout(timerId);
+      }
+      watchedScript?.removeEventListener("error", handleScriptError);
+    };
+    const handleScriptError = () => {
+      cleanup();
+      reject(new Error("MathJax could not be loaded from the CDN. Check your connection and try again."));
+    };
+    const checkStartup = () => {
+      const currentMathJax = getMathJaxGlobal();
+      if (isMathJaxReady(currentMathJax) || currentMathJax?.startup?.promise) {
+        cleanup();
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        cleanup();
+        reject(new MathJaxTimeoutError("starting", timeoutMs));
+        return;
+      }
+
+      // The async script tag appears after this shared inline script, so it may not
+      // exist on the first check. Attach the network-error listener once it does.
+      const script = document.getElementById("MathJax-script") as HTMLScriptElement | null;
+      if (script && script !== watchedScript) {
+        watchedScript?.removeEventListener("error", handleScriptError);
+        watchedScript = script;
+        watchedScript.addEventListener("error", handleScriptError, { once: true });
+      }
+      timerId = window.setTimeout(checkStartup, 25);
+    };
+
+    checkStartup();
+  });
+  mathJaxGlobal = getMathJaxGlobal();
+
+  if (mathJaxGlobal?.startup?.promise) {
+    const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt));
+    await withMathJaxTimeout(mathJaxGlobal.startup.promise, remainingMs, "starting");
+  }
+
+  mathJaxGlobal = getMathJaxGlobal();
+  if (!isMathJaxReady(mathJaxGlobal)) {
+    throw new Error("MathJax finished loading without its SVG renderer. Reload the sidebar and try again.");
+  }
+  return mathJaxGlobal;
+}
+
+function waitForMathJaxStartup(timeoutMs = MATHJAX_STARTUP_TIMEOUT_MS): Promise<SharedMathJaxApi> {
+  const readyMathJax = getMathJaxGlobal();
+  if (isMathJaxReady(readyMathJax) && readyMathJax === mathJaxReadyInstance) {
+    return Promise.resolve(readyMathJax);
+  }
+  if (!mathJaxStartupWait) {
+    const startupWait = waitForMathJaxStartupInternal(timeoutMs);
+    mathJaxStartupWait = startupWait;
+    const clearStartupWait = () => {
+      if (mathJaxStartupWait === startupWait) {
+        mathJaxStartupWait = null;
+      }
+    };
+    // REASON: cache only the in-flight startup wait. A failed worker can poison its
+    // promise, so retries must be allowed to observe a newly loaded instance; a
+    // successfully confirmed instance gets its own fast path above.
+    void startupWait.then(
+      ready => {
+        mathJaxReadyInstance = ready;
+        clearStartupWait();
+      },
+      clearStartupWait
+    );
+  }
+  return mathJaxStartupWait;
+}
 
 async function mapWithConcurrency<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
   const results: R[] = new Array(items.length);
@@ -65,16 +240,18 @@ async function renderEquationPngWithMathJax(
 ): Promise<Blob> {
   const equationBody = prepareEquationForMathJax(renderOptions.equation);
   const equation = `\\color[RGB]{${renderOptions.r},${renderOptions.g},${renderOptions.b}}` + equationBody;
+  const equationTimeoutMs = getMathJaxEquationTimeoutMs(renderOptions.equation.length);
 
-  const mathJaxGlobal = (window as unknown as { MathJax?: typeof MathJax }).MathJax;
-  if (!mathJaxGlobal || typeof mathJaxGlobal.tex2svgPromise !== "function") {
-    throw new Error("MathJax is still loading. Please try again in a moment.");
-  }
+  const mathJaxGlobal = await waitForMathJaxStartup();
 
-  const result = await mathJaxGlobal.tex2svgPromise(equation, {
-    display: !renderOptions.inline,
-    em: renderOptions.size
-  });
+  const result = await withMathJaxTimeout(
+    mathJaxGlobal.tex2svgPromise(equation, {
+      display: !renderOptions.inline,
+      em: renderOptions.size
+    }),
+    equationTimeoutMs,
+    "typesetting an equation"
+  );
   const svg = result.querySelector("svg") as SVGSVGElement | null;
   if (!svg) {
     throw new Error("MathJax did not return an SVG element.");
@@ -131,17 +308,18 @@ async function renderEquationPngWithMathJax(
 
   try {
     const svgImage = new Image(width, height);
-    svgImage.src = svgUrl;
-    await new Promise<void>((resolve, reject) => {
+    const imageLoad = new Promise<void>((resolve, reject) => {
       svgImage.onload = () => resolve();
       svgImage.onerror = err => reject(err);
     });
+    svgImage.src = svgUrl;
+    await withMathJaxTimeout(imageLoad, equationTimeoutMs, "loading the rendered equation image");
 
     ctx.drawImage(svgImage, 0, 0);
 
-    return "convertToBlob" in canvas
-      ? await (canvas as OffscreenCanvas).convertToBlob({ type: "image/png" })
-      : await new Promise<Blob>((resolve, reject) => {
+    const pngExport = "convertToBlob" in canvas
+      ? (canvas as OffscreenCanvas).convertToBlob({ type: "image/png" })
+      : new Promise<Blob>((resolve, reject) => {
           (canvas as HTMLCanvasElement).toBlob(blob => {
             if (blob) {
               resolve(blob);
@@ -150,6 +328,7 @@ async function renderEquationPngWithMathJax(
             }
           }, "image/png");
         });
+    return await withMathJaxTimeout(pngExport, equationTimeoutMs, "creating the equation image");
   } finally {
     URL.revokeObjectURL(svgUrl);
   }

--- a/tests/mathjax-sidebar-runtime.test.js
+++ b/tests/mathjax-sidebar-runtime.test.js
@@ -13,6 +13,25 @@ const sharedMathJaxSource = fs.readFileSync(
   path.join(__dirname, "..", "SidebarMathJaxShared.ts"),
   "utf8"
 );
+const docsSidebarSource = fs.readFileSync(
+  path.join(__dirname, "..", "Docs", "Sidebar.ts"),
+  "utf8"
+);
+
+function loadSharedMathJaxRuntime(context = {}) {
+  const transpiled = ts.transpileModule(sharedMathJaxSource, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText;
+  context.window ||= {
+    setTimeout,
+    clearTimeout,
+  };
+  vm.createContext(context);
+  vm.runInContext(transpiled, context);
+  return context;
+}
 
 function prepareEquationForMathJax(equation) {
   const transpiled = ts.transpileModule(sharedMathJaxSource, {
@@ -40,6 +59,123 @@ test("Docs and Slides sidebars use the MathJax release that fixes the Package ge
 
 test("the combined tex-svg component is not recursively loaded during startup", () => {
   assert.doesNotMatch(buildSidebarSource, /load:\s*\[[^\]]*['"]tex-svg['"]/);
+});
+
+test("a permanently pending MathJax startup is rejected and can be retried", async () => {
+  const runtime = loadSharedMathJaxRuntime({
+    window: {
+      setTimeout,
+      clearTimeout,
+      MathJax: {
+        startup: { promise: new Promise(() => {}) },
+        tex2svgPromise: async () => ({}),
+        svgStylesheet: () => ({}),
+      },
+    },
+  });
+
+  await assert.rejects(
+    vm.runInContext("waitForMathJaxStartup(20)", runtime),
+    error => error?.name === "MathJaxTimeoutError" && /while starting/.test(error.message)
+  );
+
+  runtime.window.MathJax = {
+    tex2svgPromise: async () => ({}),
+    svgStylesheet: () => ({}),
+  };
+  assert.equal(
+    await vm.runInContext("waitForMathJaxStartup(20)", runtime),
+    runtime.window.MathJax,
+    "the rejected cached startup wait must not poison a retry"
+  );
+});
+
+test("a slow but healthy MathJax startup completes before its deadline", async () => {
+  let finishStartup;
+  const startupPromise = new Promise(resolve => {
+    finishStartup = resolve;
+  });
+  const runtime = loadSharedMathJaxRuntime({
+    window: {
+      setTimeout,
+      clearTimeout,
+      MathJax: {
+        startup: { promise: startupPromise },
+        tex2svgPromise: async () => ({}),
+        svgStylesheet: () => ({}),
+      },
+    },
+  });
+
+  setTimeout(finishStartup, 30);
+  assert.equal(
+    await vm.runInContext("waitForMathJaxStartup(200)", runtime),
+    runtime.window.MathJax
+  );
+});
+
+test("a stalled render stage rejects instead of remaining pending", async () => {
+  const runtime = loadSharedMathJaxRuntime();
+  runtime.neverSettles = new Promise(() => {});
+
+  await assert.rejects(
+    vm.runInContext(
+      "withMathJaxTimeout(neverSettles, 20, 'typesetting an equation')",
+      runtime
+    ),
+    error => error?.name === "MathJaxTimeoutError" && /typesetting an equation/.test(error.message)
+  );
+});
+
+test("slow successful work still resolves before its deadline", async () => {
+  const runtime = loadSharedMathJaxRuntime();
+  runtime.slowSuccess = new Promise(resolve => setTimeout(() => resolve("rendered"), 30));
+
+  assert.equal(
+    await vm.runInContext(
+      "withMathJaxTimeout(slowSuccess, 200, 'typesetting an equation')",
+      runtime
+    ),
+    "rendered"
+  );
+});
+
+test("large equations receive a substantially larger render budget", () => {
+  const runtime = loadSharedMathJaxRuntime();
+  assert.equal(vm.runInContext("getMathJaxEquationTimeoutMs(0)", runtime), 120000);
+  assert.equal(vm.runInContext("getMathJaxEquationTimeoutMs(1000)", runtime), 370000);
+  assert.equal(vm.runInContext("getMathJaxEquationTimeoutMs(100000)", runtime), 900000);
+});
+
+test("typesetting, SVG loading, and PNG export all use the equation deadline", () => {
+  assert.match(
+    sharedMathJaxSource,
+    /withMathJaxTimeout\(\s*mathJaxGlobal\.tex2svgPromise\(/,
+    "MathJax typesetting should not be able to hang forever"
+  );
+  assert.match(
+    sharedMathJaxSource,
+    /withMathJaxTimeout\(imageLoad, equationTimeoutMs/,
+    "SVG image decoding should not be able to hang forever"
+  );
+  assert.match(
+    sharedMathJaxSource,
+    /withMathJaxTimeout\(pngExport, equationTimeoutMs/,
+    "canvas PNG export should not be able to hang forever"
+  );
+});
+
+test("Docs falls back in Automatic mode and surfaces explicit MathJax timeout details", () => {
+  assert.match(
+    docsSidebarSource,
+    /renderer === "auto"[\s\S]*?\.clientRenderFailed\(failed\)/,
+    "Automatic mode should continue sending timed-out equations to Texrendr fallback"
+  );
+  assert.match(
+    docsSidebarSource,
+    /timeoutErrorMessage \|\| `MathJax failed to render/,
+    "explicit MathJax mode should show the stage-specific timeout message"
+  );
 });
 
 test("small symbol packages are preloaded and bm delegates to boldsymbol", () => {


### PR DESCRIPTION
## Human intent

Rephrased from the user request and material follow-ups:

- Stop MathJax worker or startup stalls from leaving the sidebar on Loading forever.
- Preserve Automatic mode fallback to Texrendr and give explicit MathJax users a bounded, actionable error.
- Do not reject healthy but unusually large equations merely because they take longer to typeset.
- Understand the SRE dependency before changing it; this patch intentionally leaves the bundled accessibility stack unchanged.

## Root cause

The full MathJax 4.1.2 `tex-svg.js` component bundles its menu and SRE worker transitively. Auto-LaTeX did not explicitly add SRE; the original renderer configuration disabled assistive MathML. When that worker fails inside an Apps Script iframe, MathJax startup or a later client-rendering promise can remain pending forever.

## Changes

- Wait for the actual MathJax startup promise with a 30-second deadline, even when renderer methods have already appeared.
- Cache only an in-flight startup wait and clear it after success or failure so retry can observe a recovered MathJax instance.
- Bound typesetting, SVG image loading, and PNG export with an equation-scaled budget: 120 seconds plus 250 ms per source character, capped at 15 minutes.
- Preserve the existing per-equation Automatic fallback; explicit MathJax now surfaces the stage-specific timeout message.

## Timeout calibration

A read-only production-log sample from August 24-28 contained 4,868 paired successful runs: p99 completion was about 22 seconds. The largest successful batch was 8,166 equations at about 415 seconds. Across 45,016 successful equation diagnostics, the largest equation was 4,849 characters and receives the 15-minute cap. Startup stays at 30 seconds because equation complexity cannot make library startup legitimately slower.

## Validation

- `npm test` - 26 passing tests
- TypeScript no-emit checks for the shared renderer and Docs sidebar
- Docs, Slides, and Sheets sidebar build commands completed
- `git diff --check`

## Deployment

Not deployed. No Apps Script project, immutable version, deployment, or Marketplace configuration was changed.
